### PR TITLE
Add raster tile source for the vector maps legends

### DIFF
--- a/IsraelHiking.Web/appsettings.Production.json
+++ b/IsraelHiking.Web/appsettings.Production.json
@@ -9,6 +9,7 @@
     "OverlayTiles": "C:\\Users\\osmhike\\Documents\\GitHub\\IsraelHiking\\Map\\Site\\OverlayTiles",
     "OverlayMTB": "C:\\Users\\osmhike\\Documents\\GitHub\\IsraelHiking\\Map\\Site\\OverlayMTB",
     "Ortho": "C:\\Users\\osmhike\\Documents\\Maps\\Ortho2015",
+    "Legend": "C:\\Users\\osmhike\\Documents\\Maps\\Legend",
     "glyphs": "C:\\Users\\osmhike\\Documents\\GitHub\\orangemug\\font-glyphs\\glyphs",
     "PointsOfInterest": "C:\\Users\\osmhike\\Documents\\GitHub\\PointsOfInterest"
   },


### PR DESCRIPTION
Related to #1200

This additional directory can be used to as the background map source for the legends of the vector maps.