### PR TITLE
Allow specifiying a layer of a MapServer source

### DIFF
--- a/IsraelHiking.Web/sources/application/components/map/automatic-layer-presentation.component.ts
+++ b/IsraelHiking.Web/sources/application/components/map/automatic-layer-presentation.component.ts
@@ -112,7 +112,7 @@ export class AutomaticLayerPresentationComponent extends BaseMapComponent implem
     private createRasterLayer() {
         let address = this.layerData.address;
         let scheme = "xyz";
-        if (this.layerData.address.toLocaleLowerCase().endsWith("/mapserver")) {
+        if (this.layerData.address.match(/\/MapServer(\/\d+)?$/i) != null) {
             address += "/export?dpi=96&transparent=true&format=png32&bbox={bbox-epsg-3857}&bboxSR=3857&imageSR=3857&size=256,256&f=image";
         } else if (this.layerData.address.indexOf("{-y}") !== -1) {
             address = address.replace("{-y}", "{y}");


### PR DESCRIPTION
Some ESRI MapServers have multiple layers. The existing code enabled access only to the default layer 0.

This change allows an optional layer-id in the URL of the MapServer source. It is fully backward compatible with the existing code.