### PR TITLE
Do not start two builds on branch with a PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 9.3.{build}
 clone_depth: 3
 configuration: Release
+skip_branch_with_pr: true
 environment:
   STORE_PASSWORD:
     secure: ZF3GiQxQ98B1HGKZOwlnmris5yN68mvx3UF6TVsnpws=


### PR DESCRIPTION
The [problem](github.com/appveyor/ci/issues/882):

>    When you push to a feature branch and there is an open PR for that branch then AppVeyor triggers two builds: one for the branch "push" and the second one for PR "synchronize".

For example:
![image](https://user-images.githubusercontent.com/1304610/94128305-a95e4880-fe62-11ea-9ca2-e5ee7cb9ae41.png)

![image](https://user-images.githubusercontent.com/1304610/94128077-5e443580-fe62-11ea-8357-01523eedaab7.png)

The [solution](https://github.com/appveyor/ci/issues/882#issuecomment-248063991):

> Yes, it can be configured either on UI ("General" tab of project settings - `Do not build feature branches with open Pull Requests`) or in appveyor.yml:
>```
> skip_branch_with_pr: true
> ```