### PR TITLE
Add logic for mtb:name as bike route POI

### DIFF
--- a/IsraelHiking.API/Executors/FeaturesMergeExecutor.cs
+++ b/IsraelHiking.API/Executors/FeaturesMergeExecutor.cs
@@ -426,8 +426,9 @@ namespace IsraelHiking.API.Executors
                 featureToMergeTo.Attributes[FeatureAttributes.POI_ICON_COLOR] =
                     feature.Attributes[FeatureAttributes.POI_ICON_COLOR];
             }
-
-            // adding names of merged feature
+            
+            featureToMergeTo.Attributes.AddOrUpdate(FeatureAttributes.POI_MERGED, true);
+            // adding attributes of merged feature
             MergeGeometry(featureToMergeTo, feature);
             MergeTitles(featureToMergeTo, feature);
             MergeDescriptionAndAuthor(featureToMergeTo, feature);

--- a/IsraelHiking.API/Services/TagsHelper.cs
+++ b/IsraelHiking.API/Services/TagsHelper.cs
@@ -332,9 +332,9 @@ namespace IsraelHiking.API.Services
             {
                 return (1, new IconColorCategory("icon-wikipedia-w", Categories.WIKIPEDIA));
             }
-            if (attributesTable.GetNames().Any(k => k == "mtb:name"))
+            if (attributesTable.GetNames().Any(k => k.Contains("mtb:name")))
             {
-                return (1, new IconColorCategory("icon-bike"));
+                return (1, new IconColorCategory("icon-bike", Categories.ROUTE_BIKE, "gray", string.Empty));
             }
             if (attributesTable.GetNames().Any(k => k == "highway"))
             {

--- a/IsraelHiking.Common/Extensions/GeoJsonExtensions.cs
+++ b/IsraelHiking.Common/Extensions/GeoJsonExtensions.cs
@@ -245,10 +245,11 @@ namespace IsraelHiking.Common.Extensions
                    feature.HasExtraData(language);
         }
 
-        public static bool HasExtraData(this IFeature feature, string language)
+        private static bool HasExtraData(this IFeature feature, string language)
         {
             return feature.Attributes.GetByLanguage(FeatureAttributes.DESCRIPTION, language) != string.Empty ||
-                   feature.Attributes.GetNames().Any(n => n.StartsWith(FeatureAttributes.IMAGE_URL));
+                   feature.Attributes.GetNames().Any(n => n.StartsWith(FeatureAttributes.IMAGE_URL)) ||
+                   feature.Attributes.GetNames().Any(n => n.Contains("mtb:name"));
         }
 
         public static long GetOsmId(this IFeature feature)

--- a/IsraelHiking.Common/Strings.cs
+++ b/IsraelHiking.Common/Strings.cs
@@ -76,6 +76,7 @@
         public const string POI_REMOVED_URLS = POI_PREFIX + "RemovedUrls";
         public const string POI_ADDED_IMAGES = POI_PREFIX + "AddedImages";
         public const string POI_REMOVED_IMAGES = POI_PREFIX + "RemovedImages";
+        public const string POI_MERGED = POI_PREFIX + "Merged";
         
         public static readonly string[] POI_DESCRIPTION_KEYS =
         {

--- a/IsraelHiking.DataAccess/OsmLatestFileGateway.cs
+++ b/IsraelHiking.DataAccess/OsmLatestFileGateway.cs
@@ -35,6 +35,7 @@ namespace IsraelHiking.DataAccess
         /// <inheritdoc />
         public async Task<Stream> Get()
         {
+            //return await Task.FromResult(new MemoryStream(File.ReadAllBytes("/Users/user/Downloads/israel-and-palestine.osm.pbf")) as Stream);
             var client = _httpClientFactory.CreateClient();
             _logger.LogInformation($"Starting to fetch OSM file from {_options.OsmFileAddress}");
             client.Timeout = TimeSpan.FromMinutes(20);

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.html
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.html
@@ -1,11 +1,11 @@
 ﻿<div [dir]="resources.direction">
-    <mat-card-header *ngIf="!isPoint()">
+    <mat-card-header *ngIf="!info.canEditTitle">
         <mat-card-title [ngClass]="resources.getTextAlignment(info.title)" [dir]="resources.getDirection(info.title)">
             <span class="text-large" [dir]="resources.getDirection(info.title)">{{info.title}}</span>
         </mat-card-title>
     </mat-card-header>
     <div fxLayout="row">
-        <mat-form-field fxFill *ngIf="isPoint()">
+        <mat-form-field fxFill *ngIf="info.canEditTitle">
             <input matInput type="text" [dir]="resources.getDirection(info.title)" [(ngModel)]="info.title" placeholder="{{resources.nameInLanguage}}" fxFill />
         </mat-form-field>
     </div>

--- a/IsraelHiking.Web/src/application/models/point-of-interest.d.ts
+++ b/IsraelHiking.Web/src/application/models/point-of-interest.d.ts
@@ -26,5 +26,6 @@ export type EditablePublicPointData = {
     urls: string[];
     category: string;
     isPoint: boolean;
+    canEditTitle: boolean;
     lengthInKm?: number;
 };

--- a/IsraelHiking.Web/src/application/services/poi.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.spec.ts
@@ -304,7 +304,8 @@ describe("Poi Service", () => {
                     description: "description",
                     imagesUrls: ["some-image-url"],
                     title: "title",
-                    urls: ["some-url"]
+                    urls: ["some-url"],
+                    canEditTitle: true
                 }, { lat: 0, lng: 0}).then(() => {
                     expect(MockNgRedux.store.dispatch).toHaveBeenCalled();
                     expect(spy.calls.mostRecent().args[0].properties.poiId).not.toBeNull();
@@ -354,7 +355,8 @@ describe("Poi Service", () => {
                     description: "description",
                     imagesUrls: ["some-new-image-url"],
                     title: "title",
-                    urls: ["some-new-url"]
+                    urls: ["some-new-url"],
+                    canEditTitle: true
                 }, { lat: 1, lng: 2}).then(() => {
                     expect(MockNgRedux.store.dispatch).toHaveBeenCalled();
                     let feature = spy.calls.mostRecent().args[0];
@@ -421,7 +423,8 @@ describe("Poi Service", () => {
                     description: "description",
                     imagesUrls: ["some-image-url"],
                     title: "title",
-                    urls: ["some-url"]
+                    urls: ["some-url"],
+                    canEditTitle: true
                 }).then(() => {
                     expect(spy).not.toHaveBeenCalled();
                 });
@@ -477,7 +480,8 @@ describe("Poi Service", () => {
                     description: "description",
                     imagesUrls: ["some-image-url"],
                     title: "title",
-                    urls: ["some-url"]
+                    urls: ["some-url"],
+                    canEditTitle: true
                 }).then(() => {
                     expect(MockNgRedux.store.dispatch).toHaveBeenCalled();
                     let feature = spy.calls.mostRecent().args[0];

--- a/IsraelHiking.Web/src/application/services/poi.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.spec.ts
@@ -612,6 +612,16 @@ describe("Poi Service", () => {
         expect(results).toBe("desc");
     }));
 
+    it("should get title when there's mtb name with language", inject([PoiService], (poiService: PoiService) => {
+        let results = poiService.getTitle({properties: { "mtb:name:he": "name"}} as any as GeoJSON.Feature, "he");
+        expect(results).toBe("name");
+    }));
+
+    it("should get title when there's mtb name without language", inject([PoiService], (poiService: PoiService) => {
+        let results = poiService.getTitle({properties: { "mtb:name": "name"}} as any as GeoJSON.Feature, "he");
+        expect(results).toBe("name");
+    }));
+
     it("should get title even when there's no title for language description", inject([PoiService], (poiService: PoiService) => {
         let results = poiService.getTitle({properties: { name: "name"}} as any as GeoJSON.Feature, "he");
         expect(results).toBe("name");

--- a/IsraelHiking.Web/src/application/services/poi.service.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.ts
@@ -630,6 +630,12 @@ export class PoiService {
         if (feature.properties.name) {
             return feature.properties.name;
         }
+        if (feature.properties["mtb:name:"+ language]) {
+            return feature.properties["mtb:name:"+ language];
+        }
+        if (feature.properties["mtb:name"]) {
+            return feature.properties["mtb:name"];
+        }
         return "";
     }
 
@@ -803,6 +809,7 @@ export class PoiService {
             imagesUrls: Object.keys(feature.properties).filter(k => k.startsWith("image")).map(k => feature.properties[k]),
             urls: Object.keys(feature.properties).filter(k => k.startsWith("website")).map(k => feature.properties[k]),
             isPoint: feature.geometry.type === "Point" || feature.geometry.type === "MultiPoint",
+            canEditTitle: !feature.properties.poiMerged && !feature.properties["mtb:name"],
             lengthInKm: (feature.geometry.type === "LineString" || feature.geometry.type === "MultiLineString")
                 ? SpatialService.getLengthInMetersForGeometry(feature.geometry) / 1000.0
                 : null

--- a/Tests/IsraelHiking.API.Tests/Services/TagsHelperTests.cs
+++ b/Tests/IsraelHiking.API.Tests/Services/TagsHelperTests.cs
@@ -123,7 +123,7 @@ namespace IsraelHiking.API.Tests.Services
 
             Assert.AreEqual(1, factor);
             Assert.AreEqual("icon-bike", iconColorCategory.Icon);
-            Assert.AreEqual(Categories.NONE, iconColorCategory.Category);
+            Assert.AreEqual(Categories.ROUTE_BIKE, iconColorCategory.Category);
         }
     }
 }


### PR DESCRIPTION
This resolves #1768.
It adds these routes to the POI layer with a gray bike icon as can be seen in the linked issue.