### PR TITLE
Fix Modal height

### DIFF
--- a/IsraelHiking.Web/src/scss/dialogs.scss
+++ b/IsraelHiking.Web/src/scss/dialogs.scss
@@ -61,7 +61,7 @@
 }
 
 @media(max-height:550px){
-    #dialogContentForScroll {
+    .mat-mdc-dialog-content {
        max-height: calc(100vh - 170px);
    }
 }

--- a/IsraelHiking.Web/src/scss/dialogs.scss
+++ b/IsraelHiking.Web/src/scss/dialogs.scss
@@ -59,3 +59,9 @@
         height: 48px;
     }
 }
+
+@media(max-height:550px){
+    #dialogContentForScroll {
+       max-height: calc(100vh - 170px);
+   }
+}


### PR DESCRIPTION
Changed Shares and traces modal heights so on small screens modal so it will fit to screen add CSS into global modal SCSS

![shares-modal](https://github.com/user-attachments/assets/0b91375f-abc0-4f11-b402-cafc7a3af787)

I have investigated the issue, and it is not caused by the sticky bottom bar. Instead, the problem occurs due to the height of the modal or popup on smaller screens, especially in horizontal mode. The modal height is larger than the screen height, which prevents the bottom bar from being visible. I have resolved this by adjusting the modal height on small screens to ensure it fits within the screen and allows the bottom menu bar to be visible.