### PR TITLE
Add missing images from wikidata and wikipedia

### DIFF
--- a/IsraelHiking.Web/src/application/services/elevation.provider.ts
+++ b/IsraelHiking.Web/src/application/services/elevation.provider.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient } from "@angular/common/http";
 import { Store } from "@ngxs/store";
 import { timeout } from "rxjs/operators";
 import { firstValueFrom } from "rxjs";

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
@@ -59,6 +59,58 @@ describe("ImageAttributionService", () => {
         expect(response.url).toBe("https://commons.wikimedia.org/wiki/File:IHM_Image.jpeg");
     }));
 
+    it("should fetch attribution from wikimedia when getting wikimedia image with attribution and no author", inject([ImageAttributionService, HttpTestingController],
+        async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
+        const promise = service.getAttributionForImage("https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/IHM_Image.jpeg");
+        mockBackend.match(r => r.url.startsWith("https://commons.wikimedia.org/"))[0].flush({
+            query: {
+                pages: {
+                    "-1": {
+                        imageinfo: [{
+                            extmetadata: {
+                                Attribution: {
+                                    value: "hello"
+                                }
+                            }
+                        }]
+                    }
+                }
+            }
+        });
+
+        const response = await promise;
+
+        expect(response).not.toBeNull();
+        expect(response.author).toBe("hello");
+        expect(response.url).toBe("https://commons.wikimedia.org/wiki/File:IHM_Image.jpeg");
+    }));
+
+    it("should fetch attribution from wikimedia when getting wikimedia image with permissive license and no author or attribution", inject([ImageAttributionService, HttpTestingController],
+        async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
+        const promise = service.getAttributionForImage("https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/IHM_Image.jpeg");
+        mockBackend.match(r => r.url.startsWith("https://commons.wikimedia.org/"))[0].flush({
+            query: {
+                pages: {
+                    "14686480": {
+                        imageinfo: [{
+                            extmetadata: {
+                                LicenseShortName: {
+                                    value: "Cc-by-sa-3.0"
+                                }
+                            }
+                        }]
+                    }
+                }
+            }
+        });
+
+        const response = await promise;
+
+        expect(response).not.toBeNull();
+        expect(response.author).toBe("Unknown");
+        expect(response.url).toBe("https://commons.wikimedia.org/wiki/File:IHM_Image.jpeg");
+    }));
+
     it("should fetch data from wikimedia when getting wikimedia file", inject([ImageAttributionService, HttpTestingController],
         async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
         const promise = service.getAttributionForImage("File:123.jpeg");
@@ -87,8 +139,8 @@ describe("ImageAttributionService", () => {
 
     it("should remove html tags and get the value inside", inject([ImageAttributionService, HttpTestingController],
         async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
-        const promise = service.getAttributionForImage("https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/IHM_Image.jpeg");
-        mockBackend.match(r => r.url.startsWith("https://commons.wikimedia.org/"))[0].flush({
+        const promise = service.getAttributionForImage("https://upload.wikimedia.org/wikipedia/he/thumb/a/a1/IHM_Image.jpeg");
+        mockBackend.match(r => r.url.startsWith("https://he.wikipedia.org/"))[0].flush({
             query: {
                 pages: {
                     "-1": {
@@ -108,7 +160,7 @@ describe("ImageAttributionService", () => {
 
         expect(response).not.toBeNull();
         expect(response.author).toBe("hello");
-        expect(response.url).toBe("https://commons.wikimedia.org/wiki/File:IHM_Image.jpeg");
+        expect(response.url).toBe("https://he.wikipedia.org/wiki/File:IHM_Image.jpeg");
     }));
 
     it("should remove html tags, tabs and get the value inside", inject([ImageAttributionService, HttpTestingController],

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
@@ -33,7 +33,7 @@ describe("ImageAttributionService", () => {
         expect(response.url).toBe("https://www.example.com");
     }));
 
-    it("should fetch data from wikipedia when getting wikimedia image", inject([ImageAttributionService, HttpTestingController],
+    it("should fetch data from wikimedia when getting wikimedia image", inject([ImageAttributionService, HttpTestingController],
         async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
         const promise = service.getAttributionForImage("https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/IHM_Image.jpeg");
         mockBackend.match(r => r.url.startsWith("https://commons.wikimedia.org/"))[0].flush({
@@ -57,6 +57,32 @@ describe("ImageAttributionService", () => {
         expect(response).not.toBeNull();
         expect(response.author).toBe("hello");
         expect(response.url).toBe("https://commons.wikimedia.org/wiki/File:IHM_Image.jpeg");
+    }));
+
+    it("should fetch data from wikimedia when getting wikimedia file", inject([ImageAttributionService, HttpTestingController],
+        async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
+        const promise = service.getAttributionForImage("File:123.jpeg");
+        mockBackend.match(r => r.url.startsWith("https://commons.wikimedia.org/"))[0].flush({
+            query: {
+                pages: {
+                    "-1": {
+                        imageinfo: [{
+                            extmetadata: {
+                                Artist: {
+                                    value: "hello"
+                                }
+                            }
+                        }]
+                    }
+                }
+            }
+        });
+
+        const response = await promise;
+
+        expect(response).not.toBeNull();
+        expect(response.author).toBe("hello");
+        expect(response.url).toBe("https://commons.wikimedia.org/wiki/File:123.jpeg");
     }));
 
     it("should remove html tags and get the value inside", inject([ImageAttributionService, HttpTestingController],

--- a/IsraelHiking.Web/src/application/services/poi.service.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.ts
@@ -771,7 +771,7 @@ export class PoiService {
         let imagesUrls = Object.keys(feature.properties)
             .filter(k => k.startsWith("image"))
             .map(k => feature.properties[k])
-            .filter(u => u.includes("wikimedia.org") || u.includes("inature.info") || u.includes("nakeb.co.il") || u.includes("jeepolog.com"));
+            .filter((u: string) => u.startsWith("File:") || u.includes("wikimedia.org") || u.includes("inature.info") || u.includes("nakeb.co.il") || u.includes("jeepolog.com"));
         const imageAttributions = await Promise.all(imagesUrls.map(u => this.imageAttributinoService.getAttributionForImage(u)));
         imagesUrls = imagesUrls.filter((_, i) => imageAttributions[i] != null);
         return {

--- a/IsraelHiking.Web/src/application/services/wikidata.service.ts
+++ b/IsraelHiking.Web/src/application/services/wikidata.service.ts
@@ -10,14 +10,27 @@ type WikiDataPage = {
     statements: { [key: string]: { value: { content: any } }[] };
 }
 
-type WikipediaPage = {
+export type WikiPage = {
     query: {
         pages: {
             [key: string]: {
                 extract: string,
                 original?: {
                     source: string
-                }
+                };
+                imageinfo: {
+                    extmetadata: {
+                        Artist?: {
+                            value: string;
+                        };
+                        Attribution?: {
+                            value: string;
+                        };
+                        LicenseShortName?: {
+                            value: string;
+                        }
+                    };
+                }[];
             }
         },
     }
@@ -76,14 +89,15 @@ export class WikidataService {
             const indexString = GeoJSONUtils.setProperty(feature, "website", `https://${language}.wikipedia.org/wiki/${title}`);
             feature.properties["poiSourceImageUrl" + indexString] = "https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/128px-Wikipedia-logo-v2.svg.png";
         }
-        const wikipediaPage = await firstValueFrom(this.httpClient.get(`https://${language}.wikipedia.org/w/api.php?format=json&action=query&prop=extracts|pageimages&piprop=original&exintro=&explaintext=&titles=${title}&origin=*`).pipe(timeout(3000))) as unknown as WikipediaPage;
+        const wikipediaPage = await firstValueFrom(this.httpClient.get(`https://${language}.wikipedia.org/w/api.php?format=json&action=query&prop=extracts|pageimages&piprop=original&exintro=&explaintext=&titles=${title}&origin=*`).pipe(timeout(3000))) as unknown as WikiPage;
         const pagesIds = Object.keys(wikipediaPage.query.pages);
-        if (pagesIds.length > 0) {
-            const page = wikipediaPage.query.pages[pagesIds[0]];
-            feature.properties.poiExternalDescription = page.extract;
-            if (page.original?.source) {
-                GeoJSONUtils.setProperty(feature, "image", page.original.source);
-            }
+        if (pagesIds.length === 0) {
+            return;
+        }
+        const page = wikipediaPage.query.pages[pagesIds[0]];
+        feature.properties.poiExternalDescription = page.extract;
+        if (page.original?.source) {
+            GeoJSONUtils.setProperty(feature, "image", page.original.source);
         }
     }
 


### PR DESCRIPTION
- This fixes #2081.

It does so by adding "Attribution" field support and permissive licenses.
The following are the images from the linked issue:
![image](https://github.com/user-attachments/assets/93b1961d-2249-46a4-abbf-9a21c19b055a)
![image](https://github.com/user-attachments/assets/88c63458-d8ca-4bb4-a29e-b6c138af043b)
![image](https://github.com/user-attachments/assets/0d65f739-a320-4f12-8182-4825fcc5acd7)

https://israelhiking.osm.org.il/poi/OSM/node_278474873?language=he