### PR TITLE
Add support for polygons in search

### DIFF
--- a/IsraelHiking.DataAccess/ElasticSearch/BBoxDocument.cs
+++ b/IsraelHiking.DataAccess/ElasticSearch/BBoxDocument.cs
@@ -1,8 +1,25 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-public class BBoxContainer
+namespace IsraelHiking.DataAccess.ElasticSearch;
+
+public class BaseBBoxShape
 {
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+}
+
+public class MultiPolygonBBoxShape : BaseBBoxShape {
+    [JsonPropertyName("coordinates")]
+    public double[][][][] Coordinates { get; set; }
+}
+
+public class PolygonBBoxShape : BaseBBoxShape {
+    [JsonPropertyName("coordinates")]
+    public double[][][] Coordinates { get; set; }
+}
+
+public class EnvelopeBBoxShape : BaseBBoxShape {
     [JsonPropertyName("coordinates")]
     public double[][] Coordinates { get; set; }
 }
@@ -13,6 +30,7 @@ public class BBoxDocument
     public Dictionary<string, string> Name { get; set; }
     [JsonPropertyName("area")]
     public double Area { get; set; }
+    [JsonConverter(typeof(BBoxShapeGeoJsonConverter))]
     [JsonPropertyName("bbox")]
-    public BBoxContainer BBox { get; set; }
+    public BaseBBoxShape BBox { get; set; }
 }

--- a/IsraelHiking.DataAccess/ElasticSearch/BBoxShapeGeoJsonConverter.cs
+++ b/IsraelHiking.DataAccess/ElasticSearch/BBoxShapeGeoJsonConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IsraelHiking.DataAccess.ElasticSearch;
+
+public class BBoxShapeGeoJsonConverter : JsonConverter<BaseBBoxShape> {
+    public override BaseBBoxShape Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using JsonDocument document = JsonDocument.ParseValue(ref reader);
+        if (!document.RootElement.TryGetProperty("type", out var typeProperty))
+        {
+            throw new JsonException("Unable to determine GeoShape type.");
+        }
+        var type = typeProperty.GetString();
+
+        // Use a switch for cleaner logic
+        return type switch
+        {
+            "envelope" => JsonSerializer.Deserialize<EnvelopeBBoxShape>(document.RootElement.ToString(), options),
+            "polygon" => JsonSerializer.Deserialize<PolygonBBoxShape>(document.RootElement.ToString(), options),
+            "multipolygon" => JsonSerializer.Deserialize<MultiPolygonBBoxShape>(document.RootElement.ToString(), options),
+            _ => throw new JsonException($"Unknown GeoShape type: {type}") // Handle unknown types
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, BaseBBoxShape value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/IsraelHiking.Web/src/application/services/osm-tags.service.ts
+++ b/IsraelHiking.Web/src/application/services/osm-tags.service.ts
@@ -32,11 +32,13 @@ export class OsmTagsService {
         if (feature.properties.route) {
             switch (feature.properties.route) {
                 case "hiking":
+                case "foot":
                     poi.properties.poiIconColor = "black";
                     poi.properties.poiIcon = "icon-hike";
                     poi.properties.poiCategory = "Hiking";
                     return;
                 case "bicycle":
+                case "mtb":
                     poi.properties.poiIconColor = "black";
                     poi.properties.poiIcon = "icon-bike";
                     poi.properties.poiCategory = "Bicycle";

--- a/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/ElasticSearchGatewayTests.cs
+++ b/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/ElasticSearchGatewayTests.cs
@@ -40,8 +40,8 @@ public class ElasticSearchGatewayTests
     [Ignore]
     public void GetContainerName_ShouldReturnResults()
     {
-        var results = _gateway.GetContainerName([new Coordinate(35.225306, 32.703806)], "he").Result;
-        Assert.AreEqual("a", results);
+        var results = _gateway.GetContainerName([new Coordinate(35.05746, 32.596838)], "he").Result;
+        Assert.AreEqual("רמות מנשה", results);
     }
 
     [TestMethod]
@@ -107,7 +107,7 @@ public class ElasticSearchGatewayTests
     [Ignore]
     public void GetContainerName_MultipleCoordinates_ShouldGetOne()
     {
-        var name = _gateway.GetContainerName([new Coordinate(35.052338, 32.598071), new Coordinate(35.061919, 32.595458)], Languages.HEBREW).Result;
+        var name = _gateway.GetContainerName([new Coordinate(35.052338, 32.598071), new Coordinate(35.059919, 32.597458)], Languages.HEBREW).Result;
 
         Assert.AreEqual("רמות מנשה", name);
     }


### PR DESCRIPTION
This is to allow the support for both polygon and multipolygon and envelope.
After this is deployed I can migrate the planet-search to use polygons as well.
- See https://github.com/IsraelHikingMap/planet-search/issues/36