### PR TITLE
Fix Wikidata timeout

### DIFF
--- a/IsraelHiking.API/Services/Poi/WikidataPointsOfInterestAdapter.cs
+++ b/IsraelHiking.API/Services/Poi/WikidataPointsOfInterestAdapter.cs
@@ -38,9 +38,14 @@ public class WikidataPointsOfInterestAdapter : IPointsOfInterestAdapter
     public async Task<List<IFeature>> GetAll()
     {
         _logger.LogInformation("Starting getting Wikidata items for indexing.");
-        var startCoordinate = new Coordinate(34, 29);
-        var endCoordinate = new Coordinate(36, 34);
-        var allFeatures = await _wikidataGateway.GetByBoundingBox(startCoordinate, endCoordinate);
+        List<IFeature> allFeatures = new List<IFeature>();
+        for (int x = 34; x < 36; x++) {
+            for (int y = 29; y < 34; y++) {
+                var startCoordinate = new Coordinate(x, y);
+                var endCoordinate = new Coordinate(x + 1, y + 1);
+                allFeatures.AddRange(await _wikidataGateway.GetByBoundingBox(startCoordinate, endCoordinate));
+            }
+        }
         _logger.LogInformation($"Finished getting Wikidata items for indexing, got {allFeatures.Count} items.");
         return allFeatures;
     }

--- a/Tests/IsraelHiking.API.Tests/Services/Poi/WikidataPointsOfInterestAdapterTests.cs
+++ b/Tests/IsraelHiking.API.Tests/Services/Poi/WikidataPointsOfInterestAdapterTests.cs
@@ -36,8 +36,8 @@ public class WikidataPointsOfInterestAdapterTests : BasePointsOfInterestAdapterT
 
         var points = _adapter.GetAll().Result;
             
-        _wikidataGateway.Received(1).GetByBoundingBox(Arg.Any<Coordinate>(), Arg.Any<Coordinate>());
-        Assert.AreEqual(1, points.Count); // distinct by number of languages
+        _wikidataGateway.Received(10).GetByBoundingBox(Arg.Any<Coordinate>(), Arg.Any<Coordinate>());
+        Assert.AreEqual(10, points.Count);
     }
     
     [TestMethod]
@@ -51,7 +51,7 @@ public class WikidataPointsOfInterestAdapterTests : BasePointsOfInterestAdapterT
 
         var points = _adapter.GetUpdates(DateTime.Now).Result;
             
-        _wikidataGateway.Received(1).GetByBoundingBox(Arg.Any<Coordinate>(), Arg.Any<Coordinate>());
-        Assert.AreEqual(0, points.Count); // distinct by number of languages
+        _wikidataGateway.Received(10).GetByBoundingBox(Arg.Any<Coordinate>(), Arg.Any<Coordinate>());
+        Assert.AreEqual(0, points.Count);
     }
 }


### PR DESCRIPTION
There is a timeout exception when sending the request to wikidata server, this should split the query to smaller squares to allow making this query pass.