### PR TITLE
Fix large email attachment

### DIFF
--- a/IsraelHiking.Web/src/application/components/main-menu.component.ts
+++ b/IsraelHiking.Web/src/application/components/main-menu.component.ts
@@ -191,7 +191,7 @@ export class MainMenuComponent {
                 `App version: ${(await App.getInfo()).version}`
             ].join("\n");
             const geoLocationLogs = await this.geoLocationService.getLog();
-            const logBase64zipped = await this.fileService.compressTextToBase64Zip([
+            const zippedLogFileUri = await this.fileService.compressTextToLogZip([
                 { name: "log.txt", text: logs},
                 { name: "geolocation.txt", text: geoLocationLogs}
             ]);
@@ -203,9 +203,9 @@ export class MainMenuComponent {
                 subject: subject,
                 body: this.resources.reportAnIssueInstructions,
                 attachments: [{
-                    type: "base64",
+                    type: "absolute",
                     name: "log.zip",
-                    path: logBase64zipped
+                    path: zippedLogFileUri
                 }, {
                     type: "base64",
                     name: `info-${userInfo.id}.txt`,

--- a/IsraelHiking.Web/src/application/services/file.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.spec.ts
@@ -4,7 +4,6 @@ import { HttpTestingController, provideHttpClientTesting } from "@angular/common
 import { File as FileSystemWrapper } from "@awesome-cordova-plugins/file/ngx";
 import { FileTransfer } from "@awesome-cordova-plugins/file-transfer/ngx";
 import { StyleSpecification } from "maplibre-gl";
-import { decode } from "base64-arraybuffer";
 import { strToU8, zipSync, unzipSync, strFromU8 } from "fflate";
 
 import { FileService, SaveAsFactory } from "./file.service";
@@ -297,12 +296,20 @@ describe("FileService", () => {
         expect(spy).toHaveBeenCalled();
     }));
 
-    it("Should compress text to base 64 zip", inject([FileService], 
-        async (service: FileService) => {
+    it("Should compress text to zip and return uri", inject([FileService, FileSystemWrapper], 
+        async (service: FileService, fileSystemWrapper: FileSystemWrapper) => {
+            const spy = jasmine.createSpy();
+            fileSystemWrapper.writeFile = spy;
+            fileSystemWrapper.resolveLocalFilesystemUrl = jasmine.createSpy().and.returnValue(Promise.resolve({
+                nativeURL: "file:///some-file",
+            }));
             const contents = [{ name: "log.txt", text: "some text" }];
-            const compressed = await service.compressTextToBase64Zip(contents);
+            const fileUri = await service.compressTextToLogZip(contents);
             
-            const files = unzipSync(new Uint8Array(decode(compressed)));
+            expect(spy).toHaveBeenCalled();
+            expect(fileUri).toBe("/some-file");
+            const content = spy.calls.first().args[2];
+            const files = unzipSync(content);
             expect(Object.keys(files)).toEqual([contents[0].name]);
             expect(strFromU8(files[contents[0].name])).toEqual(contents[0].text);
     }));

--- a/IsraelHiking.Web/src/application/services/file.service.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.ts
@@ -268,9 +268,9 @@ export class FileService {
         }
         const result = zipSync(zippable);
         const fileName = "log.zip";
-        await this.fileSystemWrapper.writeFile(this.fileSystemWrapper.cacheDirectory, fileName, result,
-            { replace: true, append: false, truncate: 0 });
-        const entry = await this.fileSystemWrapper.resolveLocalFilesystemUrl(this.fileSystemWrapper.cacheDirectory + fileName);
+        const directory = this.runningContextService.isIos ? this.fileSystemWrapper.tempDirectory : this.fileSystemWrapper.externalCacheDirectory;
+        await this.fileSystemWrapper.writeFile(directory, fileName, result, { replace: true, append: false, truncate: 0 });
+        const entry = await this.fileSystemWrapper.resolveLocalFilesystemUrl(directory + fileName);
         return entry.nativeURL.replace("file://", "");
     }
 

--- a/IsraelHiking.Web/src/application/services/file.service.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.ts
@@ -268,8 +268,8 @@ export class FileService {
         }
         const result = zipSync(zippable);
         const fileName = "log.zip";
-        const directory = this.runningContextService.isIos ? this.fileSystemWrapper.tempDirectory : this.fileSystemWrapper.externalCacheDirectory;
-        await this.fileSystemWrapper.writeFile(directory, fileName, result, { replace: true, append: false, truncate: 0 });
+        const directory = this.fileSystemWrapper.cacheDirectory;
+        await this.fileSystemWrapper.writeFile(directory, fileName, await new Response(result).arrayBuffer(), { replace: true, append: false, truncate: 0 });
         const entry = await this.fileSystemWrapper.resolveLocalFilesystemUrl(directory + fileName);
         return entry.nativeURL.replace("file://", "");
     }

--- a/IsraelHiking.Web/src/application/services/file.service.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.ts
@@ -7,7 +7,7 @@ import { Share } from "@capacitor/share";
 import { last } from "lodash-es";
 import { firstValueFrom } from "rxjs";
 import { zipSync, strToU8, unzipSync, strFromU8, Zippable } from "fflate";
-import { decode, encode } from "base64-arraybuffer";
+import { decode } from "base64-arraybuffer";
 import type { saveAs as saveAsForType } from "file-saver";
 
 import { ImageResizeService } from "./image-resize.service";
@@ -261,13 +261,17 @@ export class FileService {
         this.loggingService.info(`[Files] Write style finished successfully: ${styleFileName}`);
     }
 
-    public async compressTextToBase64Zip(contents: {name: string; text: string}[]): Promise<string> {
+    public async compressTextToLogZip(contents: {name: string; text: string}[]): Promise<string> {
         const zippable: Zippable = {};
         for (const content of contents) {
             zippable[content.name] = strToU8(content.text);
         }
         const result = zipSync(zippable);
-        return encode(await new Response(result).arrayBuffer());
+        const fileName = "log.zip";
+        await this.fileSystemWrapper.writeFile(this.fileSystemWrapper.cacheDirectory, fileName, result,
+            { replace: true, append: false, truncate: 0 });
+        const entry = await this.fileSystemWrapper.resolveLocalFilesystemUrl(this.fileSystemWrapper.cacheDirectory + fileName);
+        return entry.nativeURL.replace("file://", "");
     }
 
     public getFileContent(file: File): Promise<string> {


### PR DESCRIPTION
- Fixes #2216 

This is due to change in the plugin and the usage of capacitor for base64 content which creates a payload that is too large for capacitor.
