### PR TITLE
Improve recording failure handling

### DIFF
--- a/IsraelHiking.Web/src/application/models/state/recorded-route-state.d.ts
+++ b/IsraelHiking.Web/src/application/models/state/recorded-route-state.d.ts
@@ -4,4 +4,5 @@ export type RecordedRouteState = {
     isRecording: boolean;
     isAddingPoi: boolean;
     route: RecordedRoute;
+    pendingProcessing: GeolocationPosition[];
 };

--- a/IsraelHiking.Web/src/application/reducers/initial-state.ts
+++ b/IsraelHiking.Web/src/application/reducers/initial-state.ts
@@ -67,7 +67,8 @@ export const initialState =
         recordedRouteState: {
             isAddingPoi: false,
             isRecording: false,
-            route: null
+            route: null,
+            pendingProcessing: []
         },
         tracesState: {
             visibleTraceId: null,

--- a/IsraelHiking.Web/src/application/reducers/recorded-route.reducer.ts
+++ b/IsraelHiking.Web/src/application/reducers/recorded-route.reducer.ts
@@ -22,6 +22,15 @@ export class AddRecordingRoutePointsAction {
     constructor(public latlngs: LatLngAltTime[]) {}
 }
 
+export class AddPendingProcessingRoutePointAction {
+    public static type = this.prototype.constructor.name;
+    constructor(public position: GeolocationPosition) {}
+}
+
+export class ClearPendingProcessingRoutePointsAction {
+    public static type = this.prototype.constructor.name;
+}
+
 export class AddRecordingPoiAction {
     public static type = this.prototype.constructor.name;
     constructor(public markerData: MarkerData) {}
@@ -36,6 +45,7 @@ export class DeleteRecordingPoiAction {
     public static type = this.prototype.constructor.name;
     constructor(public index: number) {}
 }
+
 @State<RecordedRouteState>({
     name: "recordedRouteState",
     defaults: initialState.recordedRouteState
@@ -70,6 +80,25 @@ export class RecordedRouteReducer {
     public addRecordingPoints(ctx: StateContext<RecordedRouteState>, action: AddRecordingRoutePointsAction) {
         ctx.setState(produce(ctx.getState(), lastState => {
             lastState.route.latlngs = [...lastState.route.latlngs, ...action.latlngs];
+            return lastState;
+        }));
+    }
+
+    @Action(AddPendingProcessingRoutePointAction)
+    public addPendingProcessingPoint(ctx: StateContext<RecordedRouteState>, action: AddPendingProcessingRoutePointAction) {
+        ctx.setState(produce(ctx.getState(), lastState => {
+            if (lastState.pendingProcessing == null) {
+                lastState.pendingProcessing = [];
+            }
+            lastState.pendingProcessing.push(action.position);
+            return lastState;
+        }));
+    }
+
+    @Action(ClearPendingProcessingRoutePointsAction)
+    public clearPendingProcessingPoints(ctx: StateContext<RecordedRouteState>) {
+        ctx.setState(produce(ctx.getState(), lastState => {
+            lastState.pendingProcessing = [];
             return lastState;
         }));
     }

--- a/IsraelHiking.Web/src/application/services/geo-location.service.ts
+++ b/IsraelHiking.Web/src/application/services/geo-location.service.ts
@@ -82,7 +82,7 @@ export class GeoLocationService {
             }
             if (!this.isBackground) {
                 this.ngZone.run(async () => {
-                    await this.onLocationUpdate();
+                    this.handlePositionChange(this.lastReceivedPosition);
                     this.backToForeground.next();
                 });
             }
@@ -140,7 +140,7 @@ export class GeoLocationService {
                         this.positionWhileInBackground.next(this.lastReceivedPosition);
                         return;
                     }
-                    this.onLocationUpdate();
+                    this.handlePositionChange(this.lastReceivedPosition);
                     return;
                 }
                 if (error && error.code !== "2") { // "2" is location unaavailable in the browser, ignore it.
@@ -157,12 +157,6 @@ export class GeoLocationService {
             this.wasInitialized = true;
         } catch { 
             // ignore errors.
-        }
-    }
-
-    private async onLocationUpdate() {
-        if (this.lastReceivedPosition !== null && !SpatialService.isJammingTarget(GeoLocationService.positionToLatLngTime(this.lastReceivedPosition))) {
-            this.handlePositionChange(this.lastReceivedPosition);
         }
     }
 

--- a/IsraelHiking.Web/src/application/services/geo-location.service.ts
+++ b/IsraelHiking.Web/src/application/services/geo-location.service.ts
@@ -16,9 +16,9 @@ import type { ApplicationState, LatLngAltTime } from "../models/models";
 export class GeoLocationService {
     private isBackground = false;
     private wasInitialized = false;
-    private locations: Location[] = [];
+    private lastReceivedPosition: GeolocationPosition | null = null;
 
-    public bulkPositionChanged = new EventEmitter<GeolocationPosition[]>();
+    public positionWhileInBackground = new EventEmitter<GeolocationPosition>();
     public backToForeground = new EventEmitter<void>();
 
     private readonly resources = inject(ResourcesService);
@@ -134,9 +134,10 @@ export class GeoLocationService {
                 distanceFilter: 2
             }, (location?: Location, error?: CallbackError) => {
                 if (location) {
-                    this.locations.push(location);
                     this.loggingService.debug("[GeoLocation] Received position: " + `lat: ${location.latitude}, lng: ${location.longitude}, time: ${new Date(location.time).toISOString()}, accuracy: ${location.accuracy}, background: ${this.isBackground}`);
+                    this.lastReceivedPosition = this.locationToPosition(location);
                     if (this.isBackground) {
+                        this.positionWhileInBackground.next(this.lastReceivedPosition);
                         return;
                     }
                     this.onLocationUpdate();
@@ -160,15 +161,8 @@ export class GeoLocationService {
     }
 
     private async onLocationUpdate() {
-        const locations = [...this.locations];
-        this.locations = [];
-        const positions = locations.map(l => this.locationToPosition(l)).filter(p => !SpatialService.isJammingTarget(GeoLocationService.positionToLatLngTime(p)));
-        this.loggingService.debug("[GeoLocation] Handle location update, received " + positions.length + " positions");
-        if (positions.length === 1) {
-            this.handlePositionChange(positions[0]);
-        } else if (positions.length > 1) {
-            this.bulkPositionChanged.next(positions.splice(0, positions.length - 1));
-            this.handlePositionChange(positions[0]);
+        if (this.lastReceivedPosition !== null && !SpatialService.isJammingTarget(GeoLocationService.positionToLatLngTime(this.lastReceivedPosition))) {
+            this.handlePositionChange(this.lastReceivedPosition);
         }
     }
 

--- a/IsraelHiking.Web/src/application/services/recorded-route.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/recorded-route.service.spec.ts
@@ -14,7 +14,7 @@ import { LoggingService } from "./logging.service";
 import { ToastService } from "./toast.service";
 import { RunningContextService } from "./running-context.service";
 import { ConnectionService } from "./connection.service";
-import { StopRecordingAction, RecordedRouteReducer } from "../reducers/recorded-route.reducer";
+import { StopRecordingAction, RecordedRouteReducer, ClearPendingProcessingRoutePointsAction } from "../reducers/recorded-route.reducer";
 import { AddRouteAction } from "../reducers/routes.reducer";
 import { SetCurrentPositionAction, GpsReducer } from "../reducers/gps.reducer";
 import type { ApplicationState, MarkerData } from "../models/models";
@@ -48,7 +48,10 @@ describe("Recorded Route Service", () => {
                 { provide: RunningContextService, useValue: runnningContextServiceMock },
                 { provide: ConnectionService, useValue: { stateChanged: { subscribe: () => {} }} },
                 { provide: FileSystemWrapper, useValue: {} },
-                { provide: GeoLocationService, useValue: { bulkPositionChanged: new EventEmitter() } },
+                { provide: GeoLocationService, useValue: { 
+                    positionWhileInBackground: new EventEmitter(),
+                    backToForeground: new EventEmitter()
+                } },
                 RoutesFactory,
                 RecordedRouteService,
                 provideHttpClient(withInterceptorsFromDi()),
@@ -122,8 +125,9 @@ describe("Recorded Route Service", () => {
             const spy = jasmine.createSpy();
             store.dispatch = spy;
             service.initialize();
-            expect(spy.calls.all()[0].args[0]).toBeInstanceOf(StopRecordingAction);
-            expect(spy.calls.all()[1].args[0]).toBeInstanceOf(AddRouteAction);
+            expect(spy.calls.all()[0].args[0]).toBeInstanceOf(ClearPendingProcessingRoutePointsAction);
+            expect(spy.calls.all()[1].args[0]).toBeInstanceOf(StopRecordingAction);
+            expect(spy.calls.all()[2].args[0]).toBeInstanceOf(AddRouteAction);
         }
     ));
 
@@ -148,15 +152,13 @@ describe("Recorded Route Service", () => {
         }
     ));
 
-    it("Should add a valid location", inject([RecordedRouteService, Store],
+    it("Should add a valid location when a position changes", inject([RecordedRouteService, Store],
         (service: RecordedRouteService, store: Store) => {
             store.reset({
                 recordedRouteState: {
-                    isRecording: false
-                }
-            });
-            service.initialize();
-            store.reset({
+                    isRecording: false,
+                    route: {}
+                },
                 gpsState: {
                     currentPosition: {
                         coords: {
@@ -166,43 +168,23 @@ describe("Recorded Route Service", () => {
                         },
                         timestamp: new Date(0).getTime()
                     }
-                },
-                recordedRouteState: {
-                    route: {}
-                },
-            });
-            service.startRecording();
-            store.reset({
-                userState: {},
-                gpsState: {},
-                recordedRouteState: {
-                    route: {
-                        latlngs: [{
-                            lat: 1,
-                            lng: 2,
-                            alt: 10,
-                            timestamp: new Date(0)
-                        }]
-                    },
-                    isRecording: true
                 }
             });
+            service.initialize();
+            service.startRecording();
+            positionChanged(store, { coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates, timestamp: new Date(2).getTime()} as GeolocationPosition);
 
-            positionChanged(store, { coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates, timestamp: new Date(1).getTime()} as GeolocationPosition);
-
-            expect(store.selectSnapshot((s: ApplicationState) => s.recordedRouteState).route.latlngs.length).toBe(1);
+            expect(store.selectSnapshot((s: ApplicationState) => s.recordedRouteState).route.latlngs.length).toBe(2);
         }
     ));
 
-    it("Should add a valid locations when returning from background", inject([RecordedRouteService, GeoLocationService, Store],
+    it("Should add a valid locations when a new position arrives and other are recieved while in background", inject([RecordedRouteService, GeoLocationService, Store],
         (service: RecordedRouteService, geoService: GeoLocationService, store: Store) => {
             store.reset({
                 recordedRouteState: {
-                    isRecording: false
-                }
-            });
-            service.initialize();
-            store.reset({
+                    isRecording: false,
+                    route: {}
+                },
                 gpsState: {
                     currentPosition: {
                         coords: {
@@ -213,44 +195,13 @@ describe("Recorded Route Service", () => {
                         timestamp: new Date(0).getTime()
                     }
                 },
-                recordedRouteState: {
-                    route: {}
-                },
             });
+            service.initialize();
             service.startRecording();
-            store.reset({
-                gpsState: {},
-                recordedRouteState: {
-                    route: {
-                        latlngs: [{
-                            lat: 1,
-                            lng: 2,
-                            alt: 10,
-                            timestamp: new Date(0)
-                        }]
-                    },
-                    isRecording: true
-                }
-            });
-
-            geoService.bulkPositionChanged.next([
-                {
-                    coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(1).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(60000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(120000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(180000).getTime()
-                } as GeolocationPosition
-            ]);
+            geoService.positionWhileInBackground.next({ coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates, timestamp: new Date(60000).getTime()} as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates, timestamp: new Date(120000).getTime()} as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates, timestamp: new Date(180000).getTime()} as GeolocationPosition);
+            
             positionChanged(store,
                 { coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates, timestamp: new Date(240000).getTime()} as GeolocationPosition
             );
@@ -258,16 +209,14 @@ describe("Recorded Route Service", () => {
         }
     ));
 
-    it("Should invalidate multiple locations once", inject([RecordedRouteService, GeoLocationService, LoggingService, Store],
+    it("Should invalidate multiple locations once and update recoding when comming back to foregound", inject([RecordedRouteService, GeoLocationService, LoggingService, Store],
         (service: RecordedRouteService, geoService: GeoLocationService,
          logginService: LoggingService, store: Store) => {
             store.reset({
                 recordedRouteState: {
-                    isRecording: false
-                }
-            });
-            service.initialize();
-            store.reset({
+                    isRecording: false,
+                    route: {}
+                },
                 gpsState: {
                     currentPosition: {
                         coords: {
@@ -278,56 +227,19 @@ describe("Recorded Route Service", () => {
                         timestamp: new Date(0).getTime()
                     }
                 },
-                recordedRouteState: {
-                    route: {}
-                },
             });
+            service.initialize();
             const spy = spyOn(logginService, "debug");
             service.startRecording();
-            store.reset({
-                recordedRouteState: {
-                    route: {
-                        latlngs: [{
-                            lat: 1,
-                            lng: 2,
-                            alt: 10,
-                            timestamp: new Date(0)
-                        }]
-                    },
-                    isRecording: true
-                }
-            });
+            geoService.positionWhileInBackground.next({ coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates, timestamp: new Date(150000).getTime()} as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates, timestamp: new Date(1000).getTime()} as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates, timestamp: new Date(2000).getTime()} as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates, timestamp: new Date(3000).getTime()} as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates, timestamp: new Date(3000).getTime()} as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { longitude: 1, latitude: 2, accuracy: 1000 } as GeolocationCoordinates, timestamp: new Date(4000).getTime() } as GeolocationPosition);
+            geoService.positionWhileInBackground.next({ coords: { longitude: 1.1, latitude: 2 } as GeolocationCoordinates, timestamp: new Date(5000).getTime() } as GeolocationPosition);
 
-            geoService.bulkPositionChanged.next([
-                {
-                    coords: { latitude: 1, longitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(150000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(1000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(2000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(3000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { longitude: 1, latitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(3000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { longitude: 1, latitude: 2, accuracy: 1000 } as GeolocationCoordinates,
-                    timestamp: new Date(4000).getTime()
-                } as GeolocationPosition,
-                {
-                    coords: { longitude: 1.1, latitude: 2 } as GeolocationCoordinates,
-                    timestamp: new Date(5000).getTime()
-                } as GeolocationPosition
-            ]);
+            geoService.backToForeground.next();
             expect(spy.calls.all()[0].args[0].startsWith("[Record] Valid position")).toBeTruthy();
             expect(spy.calls.all()[1].args[0].startsWith("[Record] Rejecting position,")).toBeTruthy();
             expect(spy.calls.all()[2].args[0].startsWith("[Record] Validating a rejected position")).toBeTruthy();

--- a/IsraelHiking.Web/src/application/services/recorded-route.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/recorded-route.service.spec.ts
@@ -280,13 +280,15 @@ describe("Recorded Route Service", () => {
             geoService.positionWhileInBackground.next({ coords: { longitude: 1.1, latitude: 2 } as GeolocationCoordinates, timestamp: new Date(5000).getTime() } as GeolocationPosition);
 
             geoService.backToForeground.next();
-            expect(spy.calls.all()[0].args[0].startsWith("[Record] Valid position")).toBeTruthy();
-            expect(spy.calls.all()[1].args[0].startsWith("[Record] Rejecting position,")).toBeTruthy();
-            expect(spy.calls.all()[2].args[0].startsWith("[Record] Validating a rejected position")).toBeTruthy();
-            expect(spy.calls.all()[3].args[0].startsWith("[Record] Valid position")).toBeTruthy();
-            expect(spy.calls.all()[4].args[0].startsWith("[Record] Rejecting position,")).toBeTruthy();
-            expect(spy.calls.all()[5].args[0].startsWith("[Record] Rejecting position for rejected")).toBeTruthy();
-            expect(spy.calls.all()[6].args[0].startsWith("[Record] Rejecting position for rejected")).toBeTruthy();
+            let i = 0;
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Processing 7")).toBeTruthy();
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Valid position")).toBeTruthy();
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Rejecting position,")).toBeTruthy();
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Validating a rejected position")).toBeTruthy();
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Valid position")).toBeTruthy();
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Rejecting position,")).toBeTruthy();
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Rejecting position for rejected")).toBeTruthy();
+            expect(spy.calls.all()[i++].args[0].startsWith("[Record] Rejecting position for rejected")).toBeTruthy();
 
             expect(store.selectSnapshot((s: ApplicationState) => s.recordedRouteState).route.latlngs.length).toBe(4);
     }));

--- a/IsraelHiking.Web/src/application/services/recorded-route.service.ts
+++ b/IsraelHiking.Web/src/application/services/recorded-route.service.ts
@@ -139,8 +139,8 @@ export class RecordedRouteService {
         if (!this.isRecording()) {
             return;
         }
-        let readOnlyPositions = this.store.selectSnapshot((state: ApplicationState) => state.recordedRouteState.pendingProcessing) || [];
-        let positions = [...readOnlyPositions];
+        const readOnlyPositions = this.store.selectSnapshot((state: ApplicationState) => state.recordedRouteState.pendingProcessing) || [];
+        const positions = [...readOnlyPositions];
         if (positions.length > 0) {
             this.loggingService.debug(`[Record] Processing ${positions.length} pending positions`);
         }

--- a/IsraelHiking.Web/src/application/services/recorded-route.service.ts
+++ b/IsraelHiking.Web/src/application/services/recorded-route.service.ts
@@ -139,9 +139,13 @@ export class RecordedRouteService {
         if (!this.isRecording()) {
             return;
         }
-        let positions = this.store.selectSnapshot((state: ApplicationState) => state.recordedRouteState.pendingProcessing) || [];
+        let readOnlyPositions = this.store.selectSnapshot((state: ApplicationState) => state.recordedRouteState.pendingProcessing) || [];
+        let positions = [...readOnlyPositions];
+        if (positions.length > 0) {
+            this.loggingService.debug(`[Record] Processing ${positions.length} pending positions`);
+        }
         if (position != null) {
-            positions = [...positions, position];
+            positions.push(position);
         }
         this.store.dispatch(new ClearPendingProcessingRoutePointsAction());
         if (positions.length === 0) {

--- a/IsraelHiking.Web/src/application/services/recorded-route.service.ts
+++ b/IsraelHiking.Web/src/application/services/recorded-route.service.ts
@@ -143,11 +143,12 @@ export class RecordedRouteService {
         const positions = [...readOnlyPositions];
         if (positions.length > 0) {
             this.loggingService.debug(`[Record] Processing ${positions.length} pending positions`);
+            this.store.dispatch(new ClearPendingProcessingRoutePointsAction());
         }
-        if (position != null) {
+        if (position != null && (positions.length == 0 || positions[positions.length - 1].timestamp !== position.timestamp)) {
+            // Avoid adding the same position twice due to how geolocation service works.
             positions.push(position);
         }
-        this.store.dispatch(new ClearPendingProcessingRoutePointsAction());
         if (positions.length === 0) {
             return;
         }


### PR DESCRIPTION
This adds the recorded points that were in the background when the app abruptly stops to the end of the recording.
It does so by storing the pending locations that were received while in the background to the state database, and then add them to the recording when initializing the app.
- Resolves #2221



