### PR TITLE
Split edit and show poi logic

### DIFF
--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.html
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.html
@@ -1,4 +1,15 @@
-﻿﻿<div [dir]="resources.direction">
+﻿﻿<div class="flex flex-row sticky top-0 z-10 bg-white">
+    <div class="flex-1">
+        <button mat-button class="w-full min-w-unset p-0!" (click)="save()" [disabled]="isLoading" matTooltip="{{resources.save}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Save POI"><i class="fa icon-check"></i></button>
+    </div>
+    <div class="flex-1">
+            <button mat-button class="w-full min-w-unset p-0!" (click)="close()" matTooltip="{{resources.close}}" matTooltipPosition="below">
+                <i class="fa icon-close" *ngIf="!isLoading"></i>
+                <mat-spinner diameter="24" *ngIf="isLoading"></mat-spinner>    
+            </button>
+        </div>
+</div>
+<mat-card appearance="outlined" class="mat-elevation-z0">
     <mat-card-header *ngIf="!info().canEditTitle">
         <mat-card-title [ngClass]="resources.getTextAlignment(info().title)" [dir]="resources.getDirection(info().title)">
             <span class="text-xl" [dir]="resources.getDirection(info().title)">{{info().title}}</span>
@@ -48,4 +59,7 @@
         </div>
         <br />
     </div>
-</div>
+    <div class="flex flex-row" *ngIf="info().showLocationUpdate">
+        <mat-checkbox color="primary" [(ngModel)]="updateLocation">{{resources.updateLocation}}</mat-checkbox>
+    </div>
+</mat-card>

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.html
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.html
@@ -3,11 +3,11 @@
         <button mat-button class="w-full min-w-unset p-0!" (click)="save()" [disabled]="isLoading" matTooltip="{{resources.save}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Save POI"><i class="fa icon-check"></i></button>
     </div>
     <div class="flex-1">
-            <button mat-button class="w-full min-w-unset p-0!" (click)="close()" matTooltip="{{resources.close}}" matTooltipPosition="below">
-                <i class="fa icon-close" *ngIf="!isLoading"></i>
-                <mat-spinner diameter="24" *ngIf="isLoading"></mat-spinner>    
-            </button>
-        </div>
+        <button mat-button class="w-full min-w-unset p-0!" (click)="close()" matTooltip="{{resources.close}}" matTooltipPosition="below">
+            <i class="fa icon-close" *ngIf="!isLoading"></i>
+            <mat-spinner diameter="24" *ngIf="isLoading"></mat-spinner>    
+        </button>
+    </div>
 </div>
 <mat-card appearance="outlined" class="mat-elevation-z0">
     <mat-card-header *ngIf="!info().canEditTitle">

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.ts
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.ts
@@ -2,34 +2,43 @@ import { Component, inject, input, OnInit } from "@angular/core";
 import { MatSelectChange, MatSelect } from "@angular/material/select";
 import { Dir } from "@angular/cdk/bidi";
 import { NgIf, NgClass, NgFor } from "@angular/common";
-import { MatCardHeader, MatCardTitle } from "@angular/material/card";
+import { MatCard, MatCardHeader, MatCardTitle } from "@angular/material/card";
 import { MatFormField, MatLabel, MatSuffix } from "@angular/material/form-field";
 import { MatInput } from "@angular/material/input";
+import { MatTooltip } from "@angular/material/tooltip";
 import { FormsModule } from "@angular/forms";
 import { MatIconButton, MatButton } from "@angular/material/button";
 import { MatOption } from "@angular/material/core";
+import { MatCheckbox } from "@angular/material/checkbox";
 
 import { ImageScrollerComponent } from "./image-scroller.component";
 import { PoiService, ISelectableCategory } from "../../../services/poi.service";
 import { ResourcesService } from "../../../services/resources.service";
+import { SidebarService } from "../../../services/sidebar.service";
+import { ToastService } from "../../../services/toast.service";
 import type { EditablePublicPointData, IconColorLabel } from "../../../models";
 
 @Component({
     selector: "public-poi-edit",
     templateUrl: "./public-poi-edit.component.html",
     styleUrls: ["./public-poi-edit.component.scss"],
-    imports: [Dir, NgIf, MatCardHeader, MatCardTitle, NgClass, MatFormField, MatLabel, MatInput, FormsModule, ImageScrollerComponent, NgFor, MatIconButton, MatSuffix, MatButton, MatSelect, MatOption]
+    imports: [Dir, NgIf, MatCard, MatCardHeader, MatCardTitle, NgClass, MatFormField, MatLabel, MatInput, FormsModule, ImageScrollerComponent, NgFor, MatIconButton, MatSuffix, MatButton, MatSelect, MatOption, MatTooltip, MatCheckbox]
 })
 export class PublicPointOfInterestEditComponent implements OnInit {
 
     public info = input<EditablePublicPointData>();
 
+    public isLoading: boolean = true;
     public categories: ISelectableCategory[] = [];
     public selectedCategory: ISelectableCategory = null;
+    public updateLocation: boolean = false;
 
     public readonly resources = inject(ResourcesService);
 
     private readonly poiService: PoiService = inject(PoiService);
+    private readonly sidebarService = inject(SidebarService);
+    private readonly toastService = inject(ToastService);
+    
 
     private initializeCategories() {
         const categories = this.poiService.getSelectableCategories();
@@ -96,5 +105,26 @@ export class PublicPointOfInterestEditComponent implements OnInit {
 
     public isPoint(): boolean {
         return this.info != null && this.info().isPoint;
+    }
+
+    public close() {
+        this.sidebarService.hide();
+    }
+
+    public async save() {
+        this.isLoading = true;
+        try {
+            if (!this.info().id) {
+                await this.poiService.addComplexPoi(this.info());
+            } else {
+                await this.poiService.updateComplexPoi(this.info(), this.updateLocation);
+            }
+            this.toastService.success(this.resources.dataUpdatedSuccessfullyItWillTakeTimeToSeeIt);
+            this.close();
+        } catch {
+            this.toastService.confirm({ message: this.resources.unableToSaveData, type: "Ok" });
+        } finally {
+            this.isLoading = false;
+        }
     }
 }

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.ts
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-edit.component.ts
@@ -10,6 +10,7 @@ import { FormsModule } from "@angular/forms";
 import { MatIconButton, MatButton } from "@angular/material/button";
 import { MatOption } from "@angular/material/core";
 import { MatCheckbox } from "@angular/material/checkbox";
+import { MatProgressSpinner } from "@angular/material/progress-spinner";
 
 import { ImageScrollerComponent } from "./image-scroller.component";
 import { PoiService, ISelectableCategory } from "../../../services/poi.service";
@@ -22,13 +23,13 @@ import type { EditablePublicPointData, IconColorLabel } from "../../../models";
     selector: "public-poi-edit",
     templateUrl: "./public-poi-edit.component.html",
     styleUrls: ["./public-poi-edit.component.scss"],
-    imports: [Dir, NgIf, MatCard, MatCardHeader, MatCardTitle, NgClass, MatFormField, MatLabel, MatInput, FormsModule, ImageScrollerComponent, NgFor, MatIconButton, MatSuffix, MatButton, MatSelect, MatOption, MatTooltip, MatCheckbox]
+    imports: [Dir, NgIf, MatCard, MatCardHeader, MatCardTitle, NgClass, MatFormField, MatLabel, MatInput, FormsModule, ImageScrollerComponent, NgFor, MatIconButton, MatSuffix, MatButton, MatSelect, MatOption, MatTooltip, MatCheckbox, MatProgressSpinner]
 })
 export class PublicPointOfInterestEditComponent implements OnInit {
 
     public info = input<EditablePublicPointData>();
 
-    public isLoading: boolean = true;
+    public isLoading: boolean = false;
     public categories: ISelectableCategory[] = [];
     public selectedCategory: ISelectableCategory = null;
     public updateLocation: boolean = false;

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.html
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.html
@@ -1,21 +1,21 @@
-﻿﻿<div [dir]="resources.direction" [class.minimized]="isMinimized && !isEditMode()">
+﻿﻿<div [dir]="resources.direction" *ngIf="isEditMode()">
+    <public-poi-edit [info]="osmEditableInfo"></public-poi-edit>
+</div>
+<div [dir]="resources.direction" [class.minimized]="isMinimized" *ngIf="!isEditMode()">
     <div class="flex flex-row sticky top-0 z-10 bg-white">
         <div class="flex-1" *ngIf="!isHideEditMode()">
             <button mat-button class="w-full min-w-unset p-0!" (click)="setEditMode()" matTooltip="{{resources.edit}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Edit POI"><i class="fa icon-pencil"></i></button>
         </div>
-        <div class="flex-1" *ngIf="!isEditMode()">
+        <div class="flex-1">
             <button mat-button class="w-full min-w-unset p-0!" (click)="navigateHere()" matTooltip="{{resources.navigateHere}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Navigate here"><i class="fa icon-recordings"></i></button>
         </div>
-        <div class="flex-1" *ngIf="isEditMode()">
-            <button mat-button class="w-full min-w-unset p-0!" (click)="save()" [disabled]="isLoading" matTooltip="{{resources.save}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Save POI"><i class="fa icon-check"></i></button>
-        </div>
-        <div class="flex-1" *ngIf="isRoute() && !isEditMode()">
+        <div class="flex-1" *ngIf="isRoute()">
             <button mat-button class="w-full min-w-unset p-0!" (click)="convertToRoute()" matTooltip="{{resources.convertToRoute}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Convert POI to route"><i class="fa icon-plus"></i></button>
         </div>
-        <div class="flex-1" *ngIf="!isRoute() && !isEditMode()">
+        <div class="flex-1" *ngIf="!isRoute()">
             <button mat-button class="w-full min-w-unset p-0!" (click)="addPointToRoute()" matTooltip="{{resources.addPointToRoute}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Convert POI to point"><i class="fa icon-plus"></i></button>
         </div>
-        <div class="flex-1" *ngIf="shareLinks.poiLink && !isEditMode()">
+        <div class="flex-1" *ngIf="shareLinks.poiLink">
             <mat-menu #appMenu="matMenu">
                 <div mat-menu-item disableRipple="true">
                     <div class="flex flex-row">
@@ -29,10 +29,10 @@
             </mat-menu>
             <button mat-button class="w-full min-w-unset p-0!" [matMenuTriggerFor]="appMenu" matTooltip="{{resources.share}}" matTooltipPosition="below"><i class="fa icon-share-alt"></i></button>
         </div>
-        <div class="flex-1" *ngIf="!isEditMode() && !isMinimized && isApp()">
+        <div class="flex-1" *ngIf="!isMinimized && isApp()">
             <button mat-button class="w-full min-w-unset p-0!" (click)="isMinimized = !isMinimized" matTooltip="{{resources.minimize}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Minimize POI window"><i class="fa icon-chevron-down"></i></button>
         </div>
-        <div class="flex-1" *ngIf="!isEditMode() && isMinimized && isApp()">
+        <div class="flex-1" *ngIf="isMinimized && isApp()">
             <button mat-button class="w-full min-w-unset p-0!" (click)="isMinimized = !isMinimized" matTooltip="{{resources.restore}}" matTooltipPosition="below" angulartics2On="click" angularticsCategory="POI" angularticsAction="Restore POI window"><i class="fa icon-chevron-up"></i></button>
         </div>
         <div class="flex-1">
@@ -42,52 +42,42 @@
             </button>
         </div>
     </div>
-    <div *ngIf="isEditMode()">
-        <mat-card appearance="outlined" class="mat-elevation-z0">
-            <public-poi-edit [info]="info"></public-poi-edit>
-            <div class="flex flex-row" *ngIf="showLocationUpdate">
-                <mat-checkbox color="primary" [(ngModel)]="updateLocation">{{resources.updateLocation}}</mat-checkbox>
+    <mat-card appearance="outlined" class="mat-elevation-z0">
+        <mat-card-header>
+            <mat-card-title [ngClass]="resources.getTextAlignment(title)" [dir]="resources.getDirection(title)">
+                <a *ngIf="hasUrl()" [href]="getUrl()" [target]="'_blank'" angulartics2On="click" angularticsCategory="POI" angularticsAction="View extended POI data outside site from title">
+                    <span class="text-xl">{{title}}</span>
+                </a>
+                <span *ngIf="!hasUrl()" class="text-xl">{{title}}</span>
+            </mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+            <image-scroller [images]="imagesUrls" [canEdit]="false"></image-scroller>
+            <p class="text-center" *ngIf="lengthInKm && isRoute()">{{resources.length}}: {{lengthInKm | number : '1.2-2'}} {{resources.kmUnit}}</p>
+            <div class="flex flex-row">
+                <p class="w-full break-lines" [ngClass]="resources.getTextAlignment(description)" [dir]="resources.getDirection(description)">
+                    {{description}}
+                </p>
             </div>
-        </mat-card>
-    </div>
-    <div *ngIf="!isEditMode()">
-        <mat-card appearance="outlined" class="mat-elevation-z0">
-            <mat-card-header>
-                <mat-card-title [ngClass]="resources.getTextAlignment(info.title)" [dir]="resources.getDirection(info.title)">
-                    <a *ngIf="hasUrl()" [href]="getUrl()" [target]="'_blank'" angulartics2On="click" angularticsCategory="POI" angularticsAction="View extended POI data outside site from title">
-                        <span class="text-xl">{{info.title}}</span>
-                    </a>
-                    <span *ngIf="!hasUrl()" class="text-xl">{{info.title}}</span>
-                </mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
-                <image-scroller [images]="info.imagesUrls" [canEdit]="false"></image-scroller>
-                <p class="text-center" *ngIf="info.lengthInKm && isRoute()">{{resources.length}}: {{info.lengthInKm | number : '1.2-2'}} {{resources.kmUnit}}</p>
-                <div class="flex flex-row">
-                    <p class="w-full break-lines" [ngClass]="resources.getTextAlignment(description)" [dir]="resources.getDirection(description)">
-                        {{description}}
-                    </p>
-                </div>
-                <div class="flex flex-row cursor-pointer" *ngIf="showToggleTranslation()" (click)="toggleTranslation()" angulartics2On="click" angularticsCategory="POI" angularticsAction="Toggle translation">
-                    <span class="w-full text-sm text-center">
-                        {{showingTranslated ? resources.translatedBy : resources.clickToTranslate}}
-                    </span>
-                </div>
-                <div class="flex flex-row max-sm:hidden" *ngIf="isShowSeeAlso()">
-                    <h4>{{resources.seeAlso}}</h4>
-                </div>
-                <div class="flex flex-row">
-                    <a *ngIf="getElementOsmAddress()" [href]="getElementOsmAddress()" [target]="'_blank'" class="me-2" angulartics2On="click" angularticsCategory="OSM" angularticsAction="View element in OSM">
-                        <img src="content/openstreetmap-logo.png" height="32" width="32" />
-                    </a>
-                    <a *ngFor="let urlPair of sourceImageUrls" [href]="urlPair.url" [target]="'_blank'" class="me-2" angulartics2On="click" angularticsCategory="POI" angularticsAction="View extended POI data outside site">
-                        <div *ngIf="!urlPair.imageUrl" style="width: 32px; height: 32px">
-                            <i class="fa fa-2x icon-external-link"></i>
-                        </div>
-                        <img *ngIf="urlPair.imageUrl" [src]="urlPair.imageUrl" alt="" height="32" width="32" [style.float]="resources.getImageFloat(info.title)" />
-                    </a>
-                </div>
-            </mat-card-content>
-        </mat-card>
-    </div>
+            <div class="flex flex-row cursor-pointer" *ngIf="showToggleTranslation()" (click)="toggleTranslation()" angulartics2On="click" angularticsCategory="POI" angularticsAction="Toggle translation">
+                <span class="w-full text-sm text-center">
+                    {{showingTranslated ? resources.translatedBy : resources.clickToTranslate}}
+                </span>
+            </div>
+            <div class="flex flex-row max-sm:hidden" *ngIf="isShowSeeAlso()">
+                <h4>{{resources.seeAlso}}</h4>
+            </div>
+            <div class="flex flex-row">
+                <a *ngIf="getElementOsmAddress()" [href]="getElementOsmAddress()" [target]="'_blank'" class="me-2" angulartics2On="click" angularticsCategory="OSM" angularticsAction="View element in OSM">
+                    <img src="content/openstreetmap-logo.png" height="32" width="32" />
+                </a>
+                <a *ngFor="let urlPair of sourceImageUrls" [href]="urlPair.url" [target]="'_blank'" class="me-2" angulartics2On="click" angularticsCategory="POI" angularticsAction="View extended POI data outside site">
+                    <div *ngIf="!urlPair.imageUrl" style="width: 32px; height: 32px">
+                        <i class="fa fa-2x icon-external-link"></i>
+                    </div>
+                    <img *ngIf="urlPair.imageUrl" [src]="urlPair.imageUrl" alt="" height="32" width="32" [style.float]="resources.getImageFloat(title)" />
+                </a>
+            </div>
+        </mat-card-content>
+    </mat-card>
 </div>

--- a/IsraelHiking.Web/src/application/models/index.d.ts
+++ b/IsraelHiking.Web/src/application/models/index.d.ts
@@ -11,7 +11,7 @@ export type { LocationState } from "./location-state";
 export type { Trace, TraceVisibility } from "./trace";
 export type { OsmUserDetails } from "./osm-user-details";
 export type { UserInfo } from "./user-info";
-export type { SearchResultsPointOfInterest, EditablePublicPointData } from "./point-of-interest";
+export type { SearchResultsPointOfInterest, EditablePublicPointData, UpdateablePublicPointData as UpdateablePublicPoiData } from "./point-of-interest";
 export type { NorthEast } from "./north-east";
 export type { CategoriesGroup, Category, IconColorLabel, CategoriesGroupType } from "./categories-group";
 export type { Language, LanguageCode } from "./language";

--- a/IsraelHiking.Web/src/application/models/point-of-interest.d.ts
+++ b/IsraelHiking.Web/src/application/models/point-of-interest.d.ts
@@ -12,16 +12,21 @@ export type SearchResultsPointOfInterest = {
     hasExtraData: boolean;
 };
 
-export type EditablePublicPointData = {
-    id: string;
+export type UpdateablePublicPointData = {
     title: string;
     description: string;
     icon: string;
     iconColor: string;
     imagesUrls: string[];
     urls: string[];
+}
+
+export type EditablePublicPointData = UpdateablePublicPointData & {
+    id: string;
     category: string;
     isPoint: boolean;
     canEditTitle: boolean;
-    lengthInKm?: number;
+    showLocationUpdate: boolean;
+    location: LatLngAlt;
+    originalFeature: Immutable<GeoJSON.Feature>;
 };

--- a/IsraelHiking.Web/src/application/services/geojson-utils.spec.ts
+++ b/IsraelHiking.Web/src/application/services/geojson-utils.spec.ts
@@ -73,7 +73,8 @@ describe("GeoJsonUtils", () => {
                 image6: "nakeb.co.il/image.jpg",
                 image7: "jeepolog.com/image.jpg",
                 image8: "invalid-url",
-                image9: "https://example.com/image4.gif"
+                image9: "https://example.com/image4.gif",
+                image10: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
             }
         } as any as GeoJSON.Feature;
         const validUrls = GeoJSONUtils.getValidImageUrls(feature);
@@ -82,7 +83,8 @@ describe("GeoJsonUtils", () => {
             "www.wikimedia.org/good-image.png",
             "inature.info/image.jpg",
             "nakeb.co.il/image.jpg",
-            "jeepolog.com/image.jpg"
+            "jeepolog.com/image.jpg",
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
         ]);
     });
 });

--- a/IsraelHiking.Web/src/application/services/geojson-utils.ts
+++ b/IsraelHiking.Web/src/application/services/geojson-utils.ts
@@ -64,7 +64,7 @@ export class GeoJSONUtils {
         return feature.properties["description:" + language] || feature.properties.description;
     }
 
-    public static getLocation(feature: GeoJSON.Feature): LatLngAlt {
+    public static getLocation(feature: Immutable<GeoJSON.Feature>): LatLngAlt {
         return {
             lat: feature.properties.poiGeolocation.lat,
             lng: feature.properties.poiGeolocation.lon,
@@ -86,25 +86,32 @@ export class GeoJSONUtils {
     }
 
     private static isValidImageUrl(url: string): boolean {
-            if (url.startsWith("File:")) {
-                return true;
-            }
-            if (url.includes("wikimedia.org") && 
-                !url.includes("Building_no_free_image_yet") && 
-                !url.endsWith("svg.png") &&
-                !url.endsWith("svg")) {
-                return true;
-            }
-            if (url.includes("inature.info"))
-            {
-                return true;
-            }
-            if (url.includes("nakeb.co.il")) {
-                return true;
-            }
-            if (url.includes("jeepolog.com")) {
-                return true;
-            }
-            return false;
+        if (url.startsWith("File:")) {
+            return true;
         }
+        if (url.startsWith("data:image")) {
+            return true;
+        }
+        if (url.includes("wikimedia.org") && 
+            !url.includes("Building_no_free_image_yet") && 
+            !url.endsWith("svg.png") &&
+            !url.endsWith("svg")) {
+            return true;
+        }
+        if (url.includes("inature.info"))
+        {
+            return true;
+        }
+        if (url.includes("nakeb.co.il")) {
+            return true;
+        }
+        if (url.includes("jeepolog.com")) {
+            return true;
+        }
+        return false;
+    }
+
+    public static getUrls(feature: Immutable<GeoJSON.Feature>): string[] {
+        return Object.keys(feature.properties).filter(k => k.startsWith("website")).map(k => feature.properties[k]);
+    }
 }

--- a/IsraelHiking.Web/src/application/services/poi.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.spec.ts
@@ -25,7 +25,7 @@ import { Urls } from "../urls";
 import { LayersReducer } from "../reducers/layers.reducer";
 import { AddToPoiQueueAction, OfflineReducer } from "../reducers/offline.reducer";
 import { ConfigurationReducer, SetLanguageAction } from "../reducers/configuration.reducer";
-import type { ApplicationState, Category, MarkerData } from "../models";
+import type { ApplicationState, Category, LatLngAlt, MarkerData } from "../models";
 
 describe("Poi Service", () => {
 
@@ -290,7 +290,7 @@ describe("Poi Service", () => {
         }
     ));
 
-    it("Should allow adding a point from private marker", inject([PoiService, Store], async (poiService: PoiService, store: Store) => {
+    it("Should allow adding a point from private marker for a new point", inject([PoiService, Store], async (poiService: PoiService, store: Store) => {
         const markerData = {
             description: "description",
             title: "title",
@@ -306,17 +306,52 @@ describe("Poi Service", () => {
         })
 
         const feature = await poiService.getBasicInfo("", "new", "he");
-        GeoJSONUtils.setLocation(feature, { lat: 2, lng: 1});
-        expect(GeoJSONUtils.getLocation(feature).lat).toBe(2);
-        expect(GeoJSONUtils.getLocation(feature).lng).toBe(1);
-        expect(GeoJSONUtils.getDescription(feature, "he")).toBe("description");
-        expect(GeoJSONUtils.getTitle(feature, "he")).toBe("title");
-        expect(feature.properties.image).toBe("wikimedia.org/image-url");
-        expect(feature.properties.image0).toBeUndefined();
-        expect(feature.properties.poiIcon).toBe("icon-some-type");
-    }
-)
-);
+        const data = await poiService.createEditableData(feature);
+        expect(data.location.lat).toBe(2);
+        expect(data.location.lng).toBe(1);
+        expect(data.description).toBe("description");
+        expect(data.title).toBe("title");
+        expect(data.imagesUrls[0]).toBe("wikimedia.org/image-url");
+        expect(data.icon).toBe("icon-some-type");
+        expect(data.showLocationUpdate).toBeFalsy();
+    }));
+
+    it("Should create data for updating a point from private marker by merging it, for an existing point", inject([PoiService, Store], async (poiService: PoiService, store: Store) => {
+        const markerData = {
+            description: "description",
+            title: "title",
+            type: "some-type",
+            urls: [{mimeType: "image", url: "wikimedia.org/image-url", text: "text"}],
+            latlng: { lng: 1, lat: 2}
+        };
+
+        store.reset({
+            poiState: {
+                uploadMarkerData: markerData
+            }
+        })
+
+        const feature: GeoJSON.Feature = {
+            type: "Feature",
+            geometry: {
+                type: "Point",
+                coordinates: [3, 4]
+            },
+            properties: {
+                poiId: "poi-42"
+            }
+        }
+
+        const data = await poiService.createEditableData(structuredClone(feature));
+        expect(data.location.lat).toBe(2);
+        expect(data.location.lng).toBe(1);
+        expect(data.description).toBe("description");
+        expect(data.title).toBe("title");
+        expect(data.imagesUrls[0]).toBe("wikimedia.org/image-url");
+        expect(data.icon).toBe("icon-some-type");
+        expect(data.showLocationUpdate).toBeTruthy();
+        expect(data.originalFeature).toEqual(feature);
+    }));
 
     it("Should get a point by id and source from the server", (inject([PoiService, HttpTestingController, Store],
         async (poiService: PoiService, mockBackend: HttpTestingController, store: Store) => {
@@ -359,14 +394,9 @@ describe("Poi Service", () => {
         }
     )));
 
-    it("Should get a point by id and source from OSM with iNature and Wikidata", (inject([PoiService, OverpassTurboService, Store],
-        async (poiService: PoiService, overpassTurboService: OverpassTurboService, store: Store) => {
+    it("Should get a point by id and source from OSM with iNature and Wikidata", (inject([PoiService, OverpassTurboService],
+        async (poiService: PoiService, overpassTurboService: OverpassTurboService) => {
 
-            store.reset({
-                poiState: {
-                    uploadMarkerData: null
-                }
-            });
             const id = "way_42";
             const source = "OSM";
 
@@ -401,14 +431,9 @@ describe("Poi Service", () => {
         }
     )));
 
-    it("Should get a place point by id and source from OSM with overpass extra data", (inject([PoiService, OverpassTurboService, Store],
-        async (poiService: PoiService, overpassTurboService: OverpassTurboService, store: Store) => {
+    it("Should get a place point by id and source from OSM with overpass extra data", (inject([PoiService, OverpassTurboService],
+        async (poiService: PoiService, overpassTurboService: OverpassTurboService) => {
 
-            store.reset({
-                poiState: {
-                    uploadMarkerData: null
-                }
-            });
             const id = "node_42";
             const source = "OSM";
 
@@ -557,8 +582,11 @@ describe("Poi Service", () => {
                     imagesUrls: ["some-image-url"],
                     title: "title",
                     urls: ["some-url"],
-                    canEditTitle: true
-                }, { lat: 0, lng: 0}).then(() => {
+                    canEditTitle: true,
+                    originalFeature: null,
+                    showLocationUpdate: false,
+                    location: { lat: 0, lng: 0 } as LatLngAlt
+                }).then(() => {
                     expect(store.dispatch).toHaveBeenCalled();
                     expect(spy.calls.mostRecent().args[0].properties.poiId).not.toBeNull();
                     expect(spy.calls.mostRecent().args[0].properties.poiSource).toBe("OSM");
@@ -578,21 +606,6 @@ describe("Poi Service", () => {
         inject([PoiService, DatabaseService, Store],
             async (poiService: PoiService, dbMock: DatabaseService, store: Store) => {
                 store.reset({
-                    poiState: {
-                        selectedPointOfInterest: {
-                            properties: {
-                                poiSource: "OSM",
-                                poiId: "poiId",
-                                identifier: "id",
-                                imageUrl: "wikimedia.org/some-old-image-url",
-                                website: "some-old-url"
-                            } as any,
-                            geometry: {
-                                type: "Point",
-                                coordinates: [0, 0]
-                            }
-                        } as GeoJSON.Feature
-                    },
                     offlineState: {
                         uploadPoiQueue: [] as any[]
                     }
@@ -609,8 +622,23 @@ describe("Poi Service", () => {
                     imagesUrls: ["some-new-image-url"],
                     title: "title",
                     urls: ["some-new-url"],
-                    canEditTitle: true
-                }, { lat: 1, lng: 2}).then(() => {
+                    canEditTitle: true,
+                    showLocationUpdate: true,
+                    location: { lat: 1, lng: 2 } as LatLngAlt,
+                    originalFeature: {
+                        properties: {
+                            poiSource: "OSM",
+                            poiId: "poiId",
+                            identifier: "id",
+                            imageUrl: "wikimedia.org/some-old-image-url",
+                            website: "some-old-url"
+                        } as any,
+                        geometry: {
+                            type: "Point",
+                            coordinates: [0, 0]
+                        }
+                    } as GeoJSON.Feature
+                }, true).then(() => {
                     expect(store.dispatch).toHaveBeenCalled();
                     const feature = spy.calls.mostRecent().args[0];
                     expect(feature.properties.poiId).not.toBeNull();
@@ -642,26 +670,6 @@ describe("Poi Service", () => {
         inject([PoiService, DatabaseService, Store],
             async (poiService: PoiService, dbMock: DatabaseService, store: Store) => {
                 store.reset({
-                    poiState: {
-                        selectedPointOfInterest: {
-                            properties: {
-                                poiSource: "OSM",
-                                poiId: "poiId",
-                                identifier: "id",
-                                imageUrl: "wikimedia.org/some-image-url",
-                                website: "some-url",
-                                description: "description",
-                                poiCategory: "natural",
-                                poiIcon: "icon-spring",
-                                poiIconColor: "blue",
-                                name: "title",
-                            } as any,
-                            geometry: {
-                                type: "Point",
-                                coordinates: [0, 0]
-                            }
-                        } as GeoJSON.Feature
-                    },
                     offlineState: {
                         uploadPoiQueue: [] as any[]
                     }
@@ -677,8 +685,28 @@ describe("Poi Service", () => {
                     imagesUrls: ["wikimedia.org/some-image-url"],
                     title: "title",
                     urls: ["some-url"],
-                    canEditTitle: true
-                }).then(() => {
+                    canEditTitle: true,
+                    showLocationUpdate: false,
+                    location: { lat: 0, lng: 0 } as LatLngAlt,
+                    originalFeature: {
+                        properties: {
+                            poiSource: "OSM",
+                            poiId: "poiId",
+                            identifier: "id",
+                            imageUrl: "wikimedia.org/some-image-url",
+                            website: "some-url",
+                            description: "description",
+                            poiCategory: "natural",
+                            poiIcon: "icon-spring",
+                            poiIconColor: "blue",
+                            name: "title",
+                        } as any,
+                        geometry: {
+                            type: "Point",
+                            coordinates: [0, 0]
+                        }
+                    } as GeoJSON.Feature
+                }, false).then(() => {
                     expect(spy).not.toHaveBeenCalled();
                 });
 
@@ -704,21 +732,6 @@ describe("Poi Service", () => {
                 GeoJSONUtils.setLocation(featureInQueue, { lat: 1, lng: 2 });
                 dbMock.getPoiFromUploadQueue = () => Promise.resolve(featureInQueue);
                 store.reset({
-                    poiState: {
-                        selectedPointOfInterest: {
-                            properties: {
-                                poiSource: "OSM",
-                                poiId: "poiId",
-                                identifier: "id",
-                                poiIcon: "icon-spring",
-                                poiIconColor: "blue",
-                            } as any,
-                            geometry: {
-                                type: "Point",
-                                coordinates: [0, 0]
-                            }
-                        } as GeoJSON.Feature
-                    },
                     offlineState: {
                         uploadPoiQueue: ["poiId"]
                     }
@@ -735,8 +748,23 @@ describe("Poi Service", () => {
                     imagesUrls: ["some-image-url"],
                     title: "title",
                     urls: ["some-url"],
-                    canEditTitle: true
-                }).then(() => {
+                    canEditTitle: true,
+                    showLocationUpdate: false,
+                    location: { lat: 0, lng: 0 } as LatLngAlt,
+                    originalFeature: {
+                        properties: {
+                            poiSource: "OSM",
+                            poiId: "poiId",
+                            identifier: "id",
+                            poiIcon: "icon-spring",
+                            poiIconColor: "blue",
+                        } as any,
+                        geometry: {
+                            type: "Point",
+                            coordinates: [0, 0]
+                        }
+                    } as GeoJSON.Feature
+                }, false).then(() => {
                     expect(store.dispatch).toHaveBeenCalled();
                     const feature = spy.calls.mostRecent().args[0];
                     expect(feature.properties.poiId).not.toBeNull();
@@ -762,8 +790,42 @@ describe("Poi Service", () => {
         )
     );
 
+    it("Should get null length in Km for point", inject([PoiService], async (poiService: PoiService) => {
+        const feature = {
+            properties: {
+                poiSource: "OSM",
+                poiId: "poiId",
+                identifier: "id",
+                image: "invalid-image-url",
+            } as any,
+            geometry: {
+                type: "Point",
+                coordinates: [1, 2]
+            }
+        } as GeoJSON.Feature;
+        const length = await poiService.getLengthInKm(feature);
+        expect(length).toBeNull();
+    }));
+
+     it("Should get length in Km for line", inject([PoiService], async (poiService: PoiService) => {
+        const feature = {
+            properties: {
+                poiSource: "OSM",
+                poiId: "poiId",
+                identifier: "id",
+                image: "invalid-image-url",
+            } as any,
+            geometry: {
+                type: "LineString",
+                coordinates: [[1, 2], [3, 4]]
+            }
+        } as GeoJSON.Feature;
+        const length = await poiService.getLengthInKm(feature);
+        expect(length).toBeGreaterThan(0);
+    }));
+
     it("Should filter out incompatible images",
-        inject([PoiService], async (poiService: PoiService) => {
+        inject([PoiService, Store], async (poiService: PoiService, store: Store) => {
                 const feature = {
                     properties: {
                         poiSource: "OSM",
@@ -776,15 +838,19 @@ describe("Poi Service", () => {
                         coordinates: [1, 2]
                     }
                 } as GeoJSON.Feature;
-
-                const info = await poiService.getEditableDataFromFeature(feature);
+                store.reset({
+                    poiState: {
+                        uploadMarkerData: null
+                    }
+                });
+                const info = await poiService.createEditableData(feature);
                 expect(info.imagesUrls.length).toBe(0);
             }
         )
     );
 
     it("Should filter out invalid wikipedia images",
-        inject([PoiService], async (poiService: PoiService) => {
+        inject([PoiService, Store], async (poiService: PoiService, store: Store) => {
                 const feature = {
                     properties: {
                         poiSource: "OSM",
@@ -799,8 +865,12 @@ describe("Poi Service", () => {
                         coordinates: [1, 2]
                     }
                 } as GeoJSON.Feature;
-
-                const info = await poiService.getEditableDataFromFeature(feature);
+                store.reset({
+                    poiState: {
+                        uploadMarkerData: null
+                    }
+                });
+                const info = await poiService.createEditableData(feature);
                 expect(info.imagesUrls.length).toBe(0);
             }
         )
@@ -824,9 +894,9 @@ describe("Poi Service", () => {
                 } as GeoJSON.Feature;
                 spyOn(attributionService, "getAttributionForImage").and.returnValues(Promise.resolve(null), Promise.resolve("aaa") as any, Promise.resolve(null));
 
-                const info = await poiService.getEditableDataFromFeature(feature);
-                expect(info.imagesUrls.length).toBe(1);
-                expect(info.imagesUrls[0]).toBe("wikimedia.org/image-url1");
+                const imagesUrls = await poiService.getImagesThatHaveAttribution(feature);
+                expect(imagesUrls.length).toBe(1);
+                expect(imagesUrls[0]).toBe("wikimedia.org/image-url1");
             }
         )
     );


### PR DESCRIPTION
- Fixes #2241

This also splits the logic between editing a POI and showing a POI, especially in the images part where you can have multiple images from different sources, but you can't really remove them, and showing them for editing does not require attribution.
