### PR TITLE
Use client elevation only in specific cases

### DIFF
--- a/IsraelHiking.Web/src/application/components/intercations/route-edit-route.interaction.ts
+++ b/IsraelHiking.Web/src/application/components/intercations/route-edit-route.interaction.ts
@@ -300,7 +300,6 @@ export class RouteEditRouteInteraction {
     private runRouting = async (startLatLng: LatLngAlt, segment: RouteSegmentData): Promise<void> => {
         segment.routePoint = this.getSnappingForRoute(segment.routePoint, []);
         const latLngs =  await this.routingProvider.getRoute(startLatLng, segment.routePoint, segment.routingType);
-        await this.elevationProvider.updateHeights(latLngs);
         segment.latlngs = latLngs as LatLngAltTime[];
         const last = latLngs[latLngs.length - 1];
         segment.routePoint = this.getSnappingForRoute(segment.routePoint, [last]);

--- a/IsraelHiking.Web/src/application/services/file.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.spec.ts
@@ -13,6 +13,7 @@ import { FitBoundsService } from "./fit-bounds.service";
 import { GpxDataContainerConverterService } from "./gpx-data-container-converter.service";
 import { LoggingService } from "./logging.service";
 import { ConnectionService } from "./connection.service";
+import { ElevationProvider } from "./elevation.provider";
 import { Urls } from "../urls";
 import type { DataContainer, MarkerData, RouteData } from "../models";
 
@@ -54,6 +55,7 @@ describe("FileService", () => {
                 { provide: FitBoundsService, useValue: fitBoundsService },
                 { provide: SelectedRouteService, useValue: selectedRouteService },
                 { provide: ImageResizeService, useValue: imageResizeService },
+                { provide: ElevationProvider, useValue: {} },
                 { provide: SaveAsFactory, useFactory: () => saveAsSpy },
                 FileService,
                 provideHttpClient(withInterceptorsFromDi()),

--- a/IsraelHiking.Web/src/application/services/routing.provider.spec.ts
+++ b/IsraelHiking.Web/src/application/services/routing.provider.spec.ts
@@ -13,6 +13,7 @@ import { LoggingService } from "./logging.service";
 import { RunningContextService } from "./running-context.service";
 import { SpatialService } from "./spatial.service";
 import { PmTilesService } from "./pmtiles.service";
+import { ElevationProvider } from "./elevation.provider";
 
 const createTileFromFeatureCollection = (featureCollection: GeoJSON.FeatureCollection): ArrayBuffer => {
     const tileindex = geojsonVt(featureCollection);
@@ -42,6 +43,9 @@ describe("RoutingProvider", () => {
                 { provide: LoggingService, useValue: { error: () => { } } },
                 { provide: RunningContextService, useValue: {} },
                 { provide: PmTilesService, useValue: {} },
+                { provide: ElevationProvider, useValue: {
+                    updateHeights: () => Promise.resolve()
+                } },
                 GeoJsonParser,
                 RoutingProvider,
                 provideHttpClient(withInterceptorsFromDi()),
@@ -80,9 +84,7 @@ describe("RoutingProvider", () => {
 
     it("Should route between two points", inject([RoutingProvider, HttpTestingController],
         async (router: RoutingProvider, mockBackend: HttpTestingController) => {
-            const promise = router.getRoute({ lat: 32, lng: 35 }, { lat: 33, lng: 35 }, "Hike").then((data) => {
-                expect(data.length).toBe(3);
-            }, fail);
+            const promise = router.getRoute({ lat: 32, lng: 35 }, { lat: 33, lng: 35 }, "Hike");
 
             mockBackend.expectOne(() => true).flush(
                 {
@@ -95,12 +97,13 @@ describe("RoutingProvider", () => {
                             },
                             geometry: {
                                 type: "LineString",
-                                coordinates: [[1, 1] as GeoJSON.Position, [1.5, 1.5], [2, 2]]
+                                coordinates: [[1, 1], [1.5, 1.5], [2, 2]]
                             } as GeoJSON.LineString
                         } as GeoJSON.Feature<GeoJSON.LineString>
                     ]
                 } as GeoJSON.FeatureCollection<GeoJSON.GeometryObject>);
-            return promise;
+            const data = await promise;
+            expect(data.length).toBe(3);
         }
     ));
 

--- a/IsraelHiking.Web/src/application/urls.ts
+++ b/IsraelHiking.Web/src/application/urls.ts
@@ -9,7 +9,6 @@ export class Urls {
     public static readonly translations = "translations/";
     public static readonly urls = Urls.apiBase + "urls/";
     public static readonly health = Urls.apiBase + "health/";
-    public static readonly elevation = Urls.apiBase + "elevation";
     public static readonly routing = Urls.apiBase + "routing";
     public static readonly files = Urls.apiBase + "files";
     public static readonly openFile = Urls.files + "/open";


### PR DESCRIPTION
This moves the "non-critical" elevation request to the client.
It still uses the the routing's elevation as the main elevation and accommodate in the client side when data is missing.
This removes the need to have an elevation service on the server, but doesn't make client performance worse.