### PR TITLE
Set Capacitor error path to root

### DIFF
--- a/IsraelHiking.Web/android/app/src/main/assets/capacitor.config.json
+++ b/IsraelHiking.Web/android/app/src/main/assets/capacitor.config.json
@@ -4,7 +4,8 @@
 	"webDir": "www",
 	"server": {
 		"iosScheme": "ionic",
-		"androidScheme": "http"
+		"androidScheme": "http",
+		"errorPath": "/"
 	},
 	"cordova": {
 		"preferences": {

--- a/IsraelHiking.Web/capacitor.config.ts
+++ b/IsraelHiking.Web/capacitor.config.ts
@@ -6,7 +6,8 @@ const config: CapacitorConfig = {
   webDir: 'www',
   server: {
     iosScheme: "ionic",
-    androidScheme: "http"
+    androidScheme: "http",
+    errorPath: "/"
   },
   cordova: {
     preferences: {

--- a/IsraelHiking.Web/ios/App/App/capacitor.config.json
+++ b/IsraelHiking.Web/ios/App/App/capacitor.config.json
@@ -4,7 +4,8 @@
 	"webDir": "www",
 	"server": {
 		"iosScheme": "ionic",
-		"androidScheme": "http"
+		"androidScheme": "http",
+		"errorPath": "/"
 	},
 	"cordova": {
 		"preferences": {


### PR DESCRIPTION
- Fixes #2281

More about this fix and its limitations:
The reason for this issue, as can be read in the thread linked in the linked issue, is that iOS closes the webview after a while in the background.
When the app returns, due to how Angular works, it returns to a different address than the root address, which at this point the capacitor "backend" doesn't know what to return.
So the app returns and doesn't show anything (white screen of death).
The solution here is to make sure the `index.html` is returned in that case, and the rest should be addressed by Angular.
This has its short comings in case the user opened a share when the app was opened or the user opened a POI link.
I'm not entirely sure what will happen for an active recording, but this might be a different problem to solve given the fact that we better understand what's happening now.
There might be other edge cases, but I'm not sure it's worth addressing them now.


