### PR TITLE
Move download offline file to be parallel

### DIFF
--- a/IsraelHiking.Web/src/application/services/file.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.spec.ts
@@ -360,7 +360,7 @@ describe("FileService", () => {
 
             const fetchSpy = spyOn(window, "fetch").and.returnValue(Promise.resolve(mockResponse as any));
 
-            await expectAsync(service.downloadFileAuthenticated(url, url.split("/").pop(), null, progressSpy, new AbortController())).toBeRejected();
+            await expectAsync(service.downloadFileToCacheAuthenticated(url, url.split("/").pop(), null, progressSpy, new AbortController())).toBeRejected();
 
             expect(fetchSpy).toHaveBeenCalledTimes(1);
             expect(progressSpy).not.toHaveBeenCalled();
@@ -393,7 +393,7 @@ describe("FileService", () => {
             const fetchSpy = spyOn(window, "fetch").and.returnValue(Promise.resolve(mockResponse as any));
 
 
-            await service.downloadFileAuthenticated(url, url.split("/").pop(), null, progressSpy, new AbortController());
+            await service.downloadFileToCacheAuthenticated(url, url.split("/").pop(), null, progressSpy, new AbortController());
 
             expect(fetchSpy).toHaveBeenCalledTimes(1);
             expect(mockReader.read).toHaveBeenCalledTimes(3);
@@ -427,7 +427,7 @@ describe("FileService", () => {
             const fetchSpy = spyOn(window, "fetch").and.returnValue(Promise.resolve(mockResponse as any));
 
             const abortController = new AbortController();
-            const promise = service.downloadFileAuthenticated(url, url.split("/").pop(), null, progressSpy, abortController);
+            const promise = service.downloadFileToCacheAuthenticated(url, url.split("/").pop(), null, progressSpy, abortController);
 
             await new Promise(resolve => setTimeout(resolve, 50));
             abortController.abort();

--- a/IsraelHiking.Web/src/application/services/file.service.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.ts
@@ -324,7 +324,7 @@ export class FileService {
         }
     }
 
-    public downloadFileAuthenticated(url: string, fileName: string, token: string, progressCallback: (value: number) => void, abortController: AbortController): Promise<void> {
+    public downloadFileToCacheAuthenticated(url: string, fileName: string, token: string, progressCallback: (value: number) => void, abortController: AbortController): Promise<void> {
         this.loggingService.info(`[Files] Starting downloading and writing file to cache, file name ${fileName}`);
         let previousPercentage = 0;
         return new Promise<void>((resolve, reject) => {

--- a/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
+++ b/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
@@ -177,7 +177,7 @@ export class OfflineFilesDownloadService {
     }
 
     private async downloadAndMove(fileName: string, fileDownloadUrl: string, token: string, abortController: AbortController, fileNameIndex: number, length: number) {
-        await this.fileService.downloadFileAuthenticated(fileDownloadUrl, fileName, token,
+        await this.fileService.downloadFileToCacheAuthenticated(fileDownloadUrl, fileName, token,
             (value) => this.updateInProgressTilesList(value, fileNameIndex, length), abortController);
         if (abortController.signal.aborted) {
             return;


### PR DESCRIPTION
This allows downloading the files in parallel which can avoid a problem if one file gets stuck downloading so that if the user cancels and then resumes it will continue downloading only this file.

- Resolves #2330 