### PR TITLE
Fix offline parallel download

### DIFF
--- a/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
+++ b/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
@@ -182,6 +182,7 @@ export class OfflineFilesDownloadService {
         if (abortController.signal.aborted) {
             return;
         }
+        await this.fileService.moveFileFromCacheToDataDirectory(fileName);
         this.downloadedFilesInCurrentSession.push(fileName);
         this.loggingService.info(`[Offline Download] Finished downloading ${fileName}`);
     }


### PR DESCRIPTION
This was caused by a missing file movement from cache to data folder that was mistakenly removed in previous commit. 