### PR TITLE
Oprimize query in GetHighways method

### DIFF
--- a/IsraelHiking.DataAccess/OverpassTurboGateway.cs
+++ b/IsraelHiking.DataAccess/OverpassTurboGateway.cs
@@ -84,7 +84,7 @@ public class OverpassTurboGateway(
 
     public async Task<List<CompleteWay>> GetHighways(Coordinate northEast, Coordinate southWest)
     {
-        var query = $"[out:xml];\nway[\"highway\"][!\"construction\"]({southWest.Y},{southWest.X},{northEast.Y},{northEast.X});\nout meta;\n(._;>;);\nout;";
+        var query = $"[out:xml];\nway[\"highway\"][!\"construction\"]({southWest.Y},{southWest.X},{northEast.Y},{northEast.X});\nout meta;\n>;\nout;";
         var response = await GetQueryResponse(query);
 
         using MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(response));


### PR DESCRIPTION
Avoid a second copy of the ways, this time without metadata, in the result.