### PR TITLE
Fix quoted exact search case sensitivity

### DIFF
--- a/IsraelHiking.DataAccess/ElasticSearch/ElasticSearchGateway.cs
+++ b/IsraelHiking.DataAccess/ElasticSearch/ElasticSearchGateway.cs
@@ -221,7 +221,7 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
                 q.MultiMatch(m =>
                     m.Type(TextQueryType.Phrase)
                         .Query(searchTerm)
-                        .Fields(f => f.Fields(Languages.ArrayWithDefault.Select(l => new Field("name." + l + ".keyword"))))
+                        .Fields(f => f.Fields(Languages.ArrayWithDefault.Select(l => new Field("name." + l))))
                 )
             ).Explain()
         );


### PR DESCRIPTION
## Summary
- update exact-search query to use analyzed `name.<lang>` fields instead of case-sensitive `.keyword` subfields
- keep phrase matching semantics for quoted terms while allowing case-insensitive matches

## Why
Quoted searches like `"rees"` should match the same results as `"Rees"`.

Closes #2433

## Validation
- Could not run tests in this environment because `dotnet` is not installed.