### PR TITLE
Highlight search term in traces and cloud saves

### DIFF
--- a/IsraelHiking.Web/src/application/components/screens/shares.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/shares.component.html
@@ -124,7 +124,7 @@
         }
         @for (shareUrl of filteredShareUrls; track shareUrl.id) {
         <div [id]="'share-url-' + shareUrl.id">
-            <share-item [shareUrl]="shareUrl" [showMenu]="true" (delete)="deleteShareUrl(shareUrl)"
+            <share-item [shareUrl]="shareUrl" [showMenu]="true" [searchTerm]="currentSearchTerm" (delete)="deleteShareUrl(shareUrl)"
                 (editProperties)="openEditShareUrlDialog(shareUrl)" (open)="openShareUrl(shareUrl)"
                 (addToRoutes)="addShareUrlToRoutes(shareUrl)" (moveToRoute)="moveToShare(shareUrl)"></share-item>
         </div>

--- a/IsraelHiking.Web/src/application/components/screens/shares.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/shares.component.ts
@@ -49,6 +49,7 @@ export class SharesComponent implements OnInit {
     public mapStyle: StyleSpecification;
     public selectedShareUrl: Immutable<ShareUrl> = null;
     public filteredShareUrls: Immutable<ShareUrl[]> = [];
+    public currentSearchTerm = "";
     public routesGeoJson: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
     public sortBy: keyof ShareUrl = "lastModifiedDate";
     public sortDirection: "asc" | "desc" = "desc";
@@ -120,6 +121,7 @@ export class SharesComponent implements OnInit {
     private async runFilter() {
         const shareUrls = this.store.selectSnapshot((s: ApplicationState) => s.shareUrlsState.shareUrls);
         const searchTerm = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.searchTerm);
+        this.currentSearchTerm = searchTerm;
         const filteredShareUrls = shareUrls.filter((share: Immutable<ShareUrl>) => {
             for (const key in this.filter) {
                 const propValue = share[key as any as keyof ShareUrl];

--- a/IsraelHiking.Web/src/application/components/screens/traces.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/traces.component.html
@@ -92,7 +92,13 @@
                         {{resources.findUnmappedRoutes}}
                     </button>
                 </mat-menu>
-                {{getTraceDisplayName(trace)}}
+                @for (segment of getHighlightedSegments(getTraceDisplayName(trace)); track $index) {
+                @if (segment.isMatch) {
+                <mark>{{segment.text}}</mark>
+                } @else {
+                {{segment.text}}
+                }
+                }
             </h4>
             <div class="ms-2">
                 {{trace.timeStamp | date:resources.getDateFormat()}}
@@ -101,7 +107,13 @@
                 {{getVisibilityTranslation(trace.visibility)}}
             </div>
             <div class="ms-2">
-                {{trace.tagsString}}
+                @for (segment of getHighlightedSegments(trace.tagsString); track $index) {
+                @if (segment.isMatch) {
+                <mark>{{segment.text}}</mark>
+                } @else {
+                {{segment.text}}
+                }
+                }
             </div>
         </div>
         <div class="clear-left"></div>

--- a/IsraelHiking.Web/src/application/components/screens/traces.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/traces.component.ts
@@ -36,6 +36,7 @@ import { DataContainerService } from "../../services/data-container.service";
 import { RouteStrings } from "../../services/hash.service";
 import { DefaultStyleService } from "../../services/default-style.service";
 import { SelectedRouteService } from "../../services/selected-route.service";
+import { getHighlightSegments } from "../../utils/highlight-segments";
 import type { ApplicationState, LatLngAltTime, Trace, TraceVisibility } from "../../models";
 import { ZoomComponent } from "../zoom.component";
 
@@ -54,6 +55,7 @@ export class TracesComponent implements OnInit {
     public mapStyle: StyleSpecification;
     public filteredTraces: Immutable<Trace[]>;
     public loadingTraces: boolean = false;
+    public searchTerm = "";
     public selectedTrace: Immutable<Trace> | undefined;
     public tracesGeoJson: GeoJSON.FeatureCollection<GeoJSON.Point> | undefined = {
         type: "FeatureCollection",
@@ -197,6 +199,7 @@ export class TracesComponent implements OnInit {
 
     private runFilter() {
         const searchTerm = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.searchTerm).trim();
+        this.searchTerm = searchTerm;
         const traces = this.store.selectSnapshot((s: ApplicationState) => s.tracesState).traces;
         this.filteredTraces = orderBy(traces.filter((t) => this.findInTrace(t, searchTerm)), [this.sortBy], [this.sortDirection]);
         this.tracesGeoJson = {
@@ -277,6 +280,10 @@ export class TracesComponent implements OnInit {
             default:
                 throw new Error(`invalid visibility value: ${visibility}`);
         }
+    }
+
+    public getHighlightedSegments(value: string | null | undefined) {
+        return getHighlightSegments(value, this.searchTerm);
     }
 
     public async moveToTrace(traceId: string) {

--- a/IsraelHiking.Web/src/application/components/share-item.component.html
+++ b/IsraelHiking.Web/src/application/components/share-item.component.html
@@ -34,7 +34,13 @@
             </button>
         </mat-menu>
         }
-        {{shareUrl().title}}
+        @for (segment of getHighlightedSegments(shareUrl().title); track $index) {
+        @if (segment.isMatch) {
+        <mark>{{segment.text}}</mark>
+        } @else {
+        {{segment.text}}
+        }
+        }
     </h4>
     <div class="m-2">
         @switch (shareUrl().difficulty) {
@@ -65,7 +71,13 @@
         }
     </div>
     <div class="mx-2">
-        {{shareUrl().description}}
+        @for (segment of getHighlightedSegments(shareUrl().description); track $index) {
+        @if (segment.isMatch) {
+        <mark>{{segment.text}}</mark>
+        } @else {
+        {{segment.text}}
+        }
+        }
     </div>
     @if (shareUrl().length > 0) {
     <div class="inline-flex flex-row gap-1 text-sm mx-2">

--- a/IsraelHiking.Web/src/application/components/share-item.component.ts
+++ b/IsraelHiking.Web/src/application/components/share-item.component.ts
@@ -13,6 +13,7 @@ import { Angulartics2OnModule } from "../directives/gtag.directive";
 import { ShareUrlsService } from "../services/share-urls.service";
 import { ResourcesService } from "../services/resources.service";
 import { RunningContextService } from "../services/running-context.service";
+import { getHighlightSegments } from "../utils/highlight-segments";
 import type { ShareUrl } from "../models/";
 
 @Component({
@@ -23,6 +24,7 @@ import type { ShareUrl } from "../models/";
 export class ShareItemComponent implements OnInit {
     public shareUrl = input<Immutable<ShareUrl>>();
     public showMenu = input<boolean>(false);
+    public searchTerm = input<string>("");
     public delete = output<void>();
     public editProperties = output<void>();
     public open = output<void>();
@@ -62,5 +64,9 @@ export class ShareItemComponent implements OnInit {
         Share.share({
             url: this.shareAddress
         });
+    }
+
+    public getHighlightedSegments(value: string | null | undefined) {
+        return getHighlightSegments(value, this.searchTerm());
     }
 }

--- a/IsraelHiking.Web/src/application/utils/highlight-segments.ts
+++ b/IsraelHiking.Web/src/application/utils/highlight-segments.ts
@@ -1,0 +1,37 @@
+export type HighlightSegment = {
+    text: string;
+    isMatch: boolean;
+};
+
+function escapeRegExp(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function getHighlightSegments(value: string | null | undefined, searchTerm: string | null | undefined): HighlightSegment[] {
+    const source = value ?? "";
+    const trimmedSearchTerm = (searchTerm ?? "").trim();
+    if (!source || !trimmedSearchTerm) {
+        return [{ text: source, isMatch: false }];
+    }
+
+    const segments: HighlightSegment[] = [];
+    const regex = new RegExp(escapeRegExp(trimmedSearchTerm), "gi");
+    let lastIndex = 0;
+    let match = regex.exec(source);
+
+    while (match) {
+        const start = match.index;
+        const end = start + match[0].length;
+        if (start > lastIndex) {
+            segments.push({ text: source.substring(lastIndex, start), isMatch: false });
+        }
+        segments.push({ text: source.substring(start, end), isMatch: true });
+        lastIndex = end;
+        match = regex.exec(source);
+    }
+
+    if (lastIndex < source.length) {
+        segments.push({ text: source.substring(lastIndex), isMatch: false });
+    }
+    return segments;
+}


### PR DESCRIPTION
## Summary
- add a shared highlight-segmentation utility for safe, case-insensitive text highlighting
- highlight matching text in traces list (title and tags)
- highlight matching text in cloud saves list (title and description)

Closes #2421

## Validation
- Could not run Angular lint/tests in this environment because `ng` is not installed.