### PR TITLE
Removes popups

### DIFF
--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
@@ -80,98 +80,108 @@
                 <div [dir]="resources.getDirection(getTitle(hoverFeature))">{{getTitle(hoverFeature)}}</div>
             </mgl-popup>
             }
-            @if (selectedRoutePoint) {
-            <mgl-popup [lngLat]="selectedRoutePoint.geometry.coordinates" [closeButton]="false" [offset]="[0, -30]"
-                class="text-right" (popupClose)="selectedRoutePoint = null">
-                <div class="text-lg" [dir]="resources.getDirection(getTitle(selectedRoutePoint))">
-                    {{getTitle(selectedRoutePoint)}}
-                </div>
-                @switch (selectedRoutePoint.properties.poiDifficulty) {
-                @case ("Easy") {
-                <span class="rounded-full bg-green-500 p-2">
-                    <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
-                    {{resources.easy}}
-                </span>
-                }
-                @case ("Moderate") {
-                <span class="rounded-full bg-yellow-500 p-2">
-                    <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
-                    {{resources.legendModerate}}
-                </span>
-                }
-                @case ("Hard") {
-                <span class="rounded-full bg-red-500 p-2 text-white">
-                    <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
-                    {{resources.legendAdvanced}}
-                </span>
-                }
-                @case ("Very Hard") {
-                <span class="rounded-full bg-black p-2 text-white">
-                    <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
-                    {{resources.veryHard}}
-                </span>
-                }
-                @default {
-                <span class="rounded-full bg-gray-300 p-2">
-                    <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
-                </span>
-                }
-                }
-                <span class="mx-2">{{selectedRoutePoint.properties.poiLength | distance}}</span>
+        </mgl-map>
+        @if (selectedRoutePoint) {
+        <div class="hidden max-md:block fixed bottom-safe bg-white w-full z-30">
+            <div class="flex flex-row justify-center items-center mx-2">
+                <div class="flex-1 text-center text-xl">{{getTitle(selectedRoutePoint)}}</div>
+                <button mat-button class="w-1/6" type="button" (click)="selectedRoutePoint = null" tabindex="-1">
+                    <i class="fa fa-lg icon-close"></i>
+                </button>
+            </div>
+            @switch (selectedRoutePoint.properties.poiDifficulty) {
+            @case ("Easy") {
+            <span class="rounded-full bg-green-500 p-2">
+                <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
+                {{resources.easy}}
+            </span>
+            }
+            @case ("Moderate") {
+            <span class="rounded-full bg-yellow-500 p-2">
+                <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
+                {{resources.legendModerate}}
+            </span>
+            }
+            @case ("Hard") {
+            <span class="rounded-full bg-red-500 p-2 text-white">
+                <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
+                {{resources.legendAdvanced}}
+            </span>
+            }
+            @case ("Very Hard") {
+            <span class="rounded-full bg-black p-2 text-white">
+                <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
+                {{resources.veryHard}}
+            </span>
+            }
+            @default {
+            <span class="rounded-full bg-gray-300 p-2">
+                <i class="fa {{getIconFromType(selectedRoutePoint)}}"></i>
+            </span>
+            }
+            }
+            <span class="mx-2">{{selectedRoutePoint.properties.poiLength | distance}}</span>
+            <div class="flex flex-row">
                 <button class="mt-2" mat-button (click)="convertToRoute(selectedRoutePoint)" angulartics2On="click"
                     angularticsCategory="Public routes" angularticsAction="Add to routes">
                     <i class="fa icon-plus"></i>
                     {{resources.addToRoutes}}
                 </button>
+            </div>
+            <div class="flex flex-row">
                 <button class="mt-2" mat-button [matMenuTriggerFor]="shareMenu" angulartics2On="click"
                     angularticsCategory="Public routes" angularticsAction="Open share menu">
                     <i class="fa icon-share-alt"></i>
                     {{resources.share}}
                 </button>
-                <mat-menu #shareMenu="matMenu">
-                    <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).waze" [target]="'_blank'"
-                        angulartics2On="click" angularticsCategory="Public routes"
-                        angularticsAction="Navigate with waze">
-                        <i class="fa icon-waze"></i>
-                        {{resources.navigateWithWaze}}
-                    </a>
-                    <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).googleMaps" [target]="'_blank'"
-                        angulartics2On="click" angularticsCategory="Public routes"
-                        angularticsAction="Navigate with google maps">
-                        <i class="fa icon-map-marker"></i>
-                        {{resources.navigateWithGoogleMaps}}
-                    </a>
-                    @if (isApp()) {
-                    <button mat-menu-item (click)=share(getShareLinks(selectedRoutePoint).poiLink)
-                        angulartics2On="click" angularticsCategory="Public routes"
-                        angularticsAction="Share with os capabilities">
-                        <i class="fa icon-ellipsis-v"></i>
-                        {{resources.share}}
-                    </button>
-                    } @else {
-                    <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).facebook" [target]="'_blank'"
-                        angulartics2On="click" angularticsCategory="Public routes"
-                        angularticsAction="Share facebook poi">
-                        <i class="fa icon-facebook"></i>
-                        {{resources.shareWithFacebook}}
-                    </a>
-                    <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).whatsapp" [target]="'_blank'"
-                        angulartics2On="click" angularticsCategory="Public routes"
-                        angularticsAction="Share whatsapp poi">
-                        <i class="fa icon-whatsapp"></i>
-                        {{resources.shareWithWhatsapp}}
-                    </a>
-                    <button mat-menu-item [cdkCopyToClipboard]="getShareLinks(selectedRoutePoint).poiLink"
-                        angulartics2On="click" angularticsCategory="Public routes"
-                        angularticsAction="Share copy to clipboard poi">
-                        <i class="fa icon-clipboard"></i>
-                        {{resources.copyToClipboard}}
-                    </button>
-                    }
-                </mat-menu>
-            </mgl-popup>
-            }
-        </mgl-map>
+            </div>
+            <mat-menu #shareMenu="matMenu">
+                <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).waze" [target]="'_blank'"
+                    angulartics2On="click" angularticsCategory="Public routes" angularticsAction="Navigate with waze">
+                    <i class="fa icon-waze"></i>
+                    {{resources.navigateWithWaze}}
+                </a>
+                <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).googleMaps" [target]="'_blank'"
+                    angulartics2On="click" angularticsCategory="Public routes"
+                    angularticsAction="Navigate with google maps">
+                    <i class="fa icon-map-marker"></i>
+                    {{resources.navigateWithGoogleMaps}}
+                </a>
+                @if (isApp()) {
+                <button mat-menu-item (click)=share(getShareLinks(selectedRoutePoint).poiLink) angulartics2On="click"
+                    angularticsCategory="Public routes" angularticsAction="Share with os capabilities">
+                    <i class="fa icon-ellipsis-v"></i>
+                    {{resources.share}}
+                </button>
+                } @else {
+                <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).facebook" [target]="'_blank'"
+                    angulartics2On="click" angularticsCategory="Public routes" angularticsAction="Share facebook poi">
+                    <i class="fa icon-facebook"></i>
+                    {{resources.shareWithFacebook}}
+                </a>
+                <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).whatsapp" [target]="'_blank'"
+                    angulartics2On="click" angularticsCategory="Public routes" angularticsAction="Share whatsapp poi">
+                    <i class="fa icon-whatsapp"></i>
+                    {{resources.shareWithWhatsapp}}
+                </a>
+                <button mat-menu-item [cdkCopyToClipboard]="getShareLinks(selectedRoutePoint).poiLink"
+                    angulartics2On="click" angularticsCategory="Public routes"
+                    angularticsAction="Share copy to clipboard poi">
+                    <i class="fa icon-clipboard"></i>
+                    {{resources.copyToClipboard}}
+                </button>
+                }
+            </mat-menu>
+            <div class="flex flex-row mx-10 max-md:mx-2">
+                <div class="relative w-full h-[200px]">
+                    <img class="w-full object-contain img-center" [src]="selectedRoutePoint.properties.image" alt="">
+                </div>
+            </div>
+            <div class="flex flex-row" class="text-center text-sm">
+                <image-attribution [imageUrl]="selectedRoutePoint.properties.image"></image-attribution>
+            </div>
+        </div>
+        }
     </div>
     <div [ngClass]="{'max-md:hidden': showMap, 'max-md:w-full': !showMap}"
         class="overflow-y-auto z-10 w-1/3 magrin-top-with-toolbar pb-safe-w-button">

--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
@@ -164,7 +164,7 @@ export class PublicRoutesComponent {
             };
         }
         const bounds = SpatialService.getBoundsForFeature(fullFeature);
-        this.mapService.fitBounds(bounds, 100, { top: 100, left: 50, bottom: window.innerHeight / 3, right: 50 });
+        this.mapService.fitBounds(bounds, 100, { top: 100, left: 50, bottom: window.innerHeight / 2, right: 50 });
     }
 
     public getTitle(feature: GeoJSON.Feature<GeoJSON.Point>) {

--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
@@ -164,7 +164,7 @@ export class PublicRoutesComponent {
             };
         }
         const bounds = SpatialService.getBoundsForFeature(fullFeature);
-        this.mapService.fitBounds(bounds);
+        this.mapService.fitBounds(bounds, 100, { top: 100, left: 50, bottom: window.innerHeight / 3, right: 50 });
     }
 
     public getTitle(feature: GeoJSON.Feature<GeoJSON.Point>) {

--- a/IsraelHiking.Web/src/application/components/screens/shares.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/shares.component.html
@@ -152,42 +152,45 @@
                 </span>
             </mgl-marker>
             }
-            @if (selectedShareUrl) {
-            <mgl-popup [lngLat]="selectedShareUrl.start" [closeOnClick]="false"
-                (popupClose)="onStartPointClick(selectedShareUrl)" [offset]="[0, -15]">
-                <div class="flex flex-row">
-                    <h3>{{selectedShareUrl.title}}</h3>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="openEditShareUrlDialog(selectedShareUrl)" angulartics2On="click"
-                        angularticsCategory="Shares" angularticsAction="Edit share from map">
-                        <i class="fa icon-pencil"></i>
-                        {{resources.editProperties}}
-                    </button>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="openShareUrl(selectedShareUrl)" angulartics2On="click"
-                        angularticsCategory="Shares" angularticsAction="Open share from map">
-                        <i class="fa icon-external-link-square"></i>
-                        {{resources.openCloudSave}}
-                    </button>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="addShareUrlToRoutes(selectedShareUrl)" angulartics2On="click"
-                        angularticsCategory="Shares" angularticsAction="Add share to routes from map">
-                        <i class="fa icon-plus"></i>
-                        {{resources.addToRoutes}}
-                    </button>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="deleteShareUrl(selectedShareUrl)" angulartics2On="click"
-                        angularticsCategory="Shares" angularticsAction="Delete share from map">
-                        <i class="fa icon-trash"></i>
-                        {{resources.delete}}
-                    </button>
-                </div>
-            </mgl-popup>
-            }
         </mgl-map>
+        @if (selectedShareUrl) {
+        <div class="hidden max-md:block fixed bottom-safe bg-white w-full z-30 animate-slide-in-up">
+            <div class="flex flex-row justify-center items-center mx-2">
+                <div class="flex-1 text-center text-xl">{{selectedShareUrl.title}}</div>
+                <button mat-button class="w-1/6" type="button" (click)="onStartPointClick(selectedShareUrl)"
+                    tabindex="-1">
+                    <i class="fa fa-lg icon-close"></i>
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-menu-item (click)="openEditShareUrlDialog(selectedShareUrl)" angulartics2On="click"
+                    angularticsCategory="Shares" angularticsAction="Edit share from map">
+                    <i class="fa icon-pencil"></i>
+                    {{resources.editProperties}}
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-menu-item (click)="openShareUrl(selectedShareUrl)" angulartics2On="click"
+                    angularticsCategory="Shares" angularticsAction="Open share from map">
+                    <i class="fa icon-external-link-square"></i>
+                    {{resources.openCloudSave}}
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-menu-item (click)="addShareUrlToRoutes(selectedShareUrl)" angulartics2On="click"
+                    angularticsCategory="Shares" angularticsAction="Add share to routes from map">
+                    <i class="fa icon-plus"></i>
+                    {{resources.addToRoutes}}
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-menu-item (click)="deleteShareUrl(selectedShareUrl)" angulartics2On="click"
+                    angularticsCategory="Shares" angularticsAction="Delete share from map">
+                    <i class="fa icon-trash"></i>
+                    {{resources.delete}}
+                </button>
+            </div>
+        </div>
+        }
     </div>
 </div>

--- a/IsraelHiking.Web/src/application/components/screens/shares.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/shares.component.ts
@@ -14,7 +14,7 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { MatButtonToggle, MatButtonToggleGroup } from "@angular/material/button-toggle";
 import { Store } from "@ngxs/store";
 import { Immutable } from "immer";
-import { ControlComponent, MapComponent, MarkerComponent, PopupComponent } from "@maplibre/ngx-maplibre-gl";
+import { ControlComponent, MapComponent, MarkerComponent } from "@maplibre/ngx-maplibre-gl";
 import { orderBy } from "lodash-es";
 import type { StyleSpecification, Map } from "maplibre-gl";
 
@@ -41,7 +41,7 @@ import type { ApplicationState, ShareUrl } from "../../models";
     selector: "shares",
     templateUrl: "./shares.component.html",
     encapsulation: ViewEncapsulation.None,
-    imports: [MapComponent, LayersComponent, MatButton, MatSelect, MatOption, MatLabel, MatFormField, Dir, ShareItemComponent, FormsModule, MatMenu, MatMenuTrigger, MatCheckbox, MatMenuItem, MarkerComponent, RoutesPathComponent, PopupComponent, MatDivider, MatProgressSpinner, ZoomComponent, OsmAttributionComponent, ControlComponent, MatButtonToggle, MatButtonToggleGroup, NgClass]
+    imports: [MapComponent, LayersComponent, MatButton, MatSelect, MatOption, MatLabel, MatFormField, Dir, ShareItemComponent, FormsModule, MatMenu, MatMenuTrigger, MatCheckbox, MatMenuItem, MarkerComponent, RoutesPathComponent, MatDivider, MatProgressSpinner, ZoomComponent, OsmAttributionComponent, ControlComponent, MatButtonToggle, MatButtonToggleGroup, NgClass]
 })
 export class SharesComponent implements OnInit {
     public loading = false;
@@ -167,7 +167,7 @@ export class SharesComponent implements OnInit {
         this.routesGeoJson = { type: "FeatureCollection", features };
         this.showMap = true;
         const bounds = SpatialService.getBoundsForFeatureCollection(this.routesGeoJson);
-        this.mapService.fitBounds(bounds);
+        this.mapService.fitBounds(bounds, 100, { top: 150, left: 50, bottom: window.innerHeight / 3, right: 50 });
     }
 
     public getIconFromType(shareUrl: Immutable<ShareUrl>) {

--- a/IsraelHiking.Web/src/application/components/screens/traces.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/traces.component.html
@@ -141,42 +141,6 @@
                     </div>
                 </ng-template>
             </mgl-markers-for-clusters>
-            @if (selectedTrace) {
-            <mgl-popup [lngLat]="selectedTrace.start" [closeOnClick]="false"
-                (popupClose)="onStartPointClick(selectedTrace.id)" [offset]="[0, -15]">
-                <div class="flex flex-row">
-                    <h3>{{getTraceDisplayName(selectedTrace)}}</h3>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="editTrace(selectedTrace)" angulartics2On="click"
-                        angularticsCategory="Traces" angularticsAction="Edit OSM trace properties from popup">
-                        <i class="fa icon-pencil"></i>
-                        {{resources.editProperties}}
-                    </button>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="addTraceToRoutes(selectedTrace)" angulartics2On="click"
-                        angularticsCategory="Traces" angularticsAction="Add OSM trace to routes from popup">
-                        <i class="fa icon-plus"></i>
-                        {{resources.addToRoutes}}
-                    </button>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="deleteTrace(selectedTrace)" angulartics2On="click"
-                        angularticsCategory="Traces" angularticsAction="Delete OSM trace parts from popup">
-                        <i class="fa icon-trash"></i>
-                        {{resources.delete}}
-                    </button>
-                </div>
-                <div class="flex flex-row">
-                    <button mat-menu-item (click)="findUnmappedRoutes(selectedTrace)" angulartics2On="click"
-                        angularticsCategory="Traces" angularticsAction="Find unmapped trace parts from popup">
-                        <i class="fa icon-search"></i>
-                        {{resources.findUnmappedRoutes}}
-                    </button>
-                </div>
-            </mgl-popup>
-            }
             <mgl-geojson-source id="missing-parts" [data]="missingParts"></mgl-geojson-source>
             <mgl-layer id="missing-part-line" source="missing-parts" type="line" [paint]="{
                     'line-color': 'red',
@@ -207,5 +171,43 @@
             </mgl-marker>
             }
         </mgl-map>
+        @if (selectedTrace) {
+        <div class="hidden max-md:block fixed bottom-safe bg-white w-full z-30">
+            <div class="flex flex-row justify-center items-center mx-2">
+                <div class="flex-1 text-center text-xl">{{getTraceDisplayName(selectedTrace)}}</div>
+                <button mat-button class="w-1/6" type="button" (click)="selectedTrace = null" tabindex="-1">
+                    <i class="fa fa-lg icon-close"></i>
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-button (click)="editTrace(selectedTrace)" angulartics2On="click"
+                    angularticsCategory="Traces" angularticsAction="Edit OSM trace properties from popup">
+                    <i class="fa icon-pencil"></i>
+                    {{resources.editProperties}}
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-button (click)="addTraceToRoutes(selectedTrace)" angulartics2On="click"
+                    angularticsCategory="Traces" angularticsAction="Add OSM trace to routes from popup">
+                    <i class="fa icon-plus"></i>
+                    {{resources.addToRoutes}}
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-button (click)="deleteTrace(selectedTrace)" angulartics2On="click"
+                    angularticsCategory="Traces" angularticsAction="Delete OSM trace parts from popup">
+                    <i class="fa icon-trash"></i>
+                    {{resources.delete}}
+                </button>
+            </div>
+            <div class="flex flex-row">
+                <button mat-button (click)="findUnmappedRoutes(selectedTrace)" angulartics2On="click"
+                    angularticsCategory="Traces" angularticsAction="Find unmapped trace parts from popup">
+                    <i class="fa icon-search"></i>
+                    {{resources.findUnmappedRoutes}}
+                </button>
+            </div>
+        </div>
+        }
     </div>
 </div>

--- a/IsraelHiking.Web/src/application/components/screens/traces.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/traces.component.ts
@@ -292,7 +292,7 @@ export class TracesComponent implements OnInit {
         this.selectedTraceGeoJson = { type: "FeatureCollection", features };
         this.showMap = true;
         const bounds = SpatialService.getBoundsForFeatureCollection(this.selectedTraceGeoJson);
-        this.mapService.fitBounds(bounds);
+        this.mapService.fitBounds(bounds, 100, { top: 100, left: 50, bottom: window.innerHeight / 3, right: 50 });
     }
 
     public onStartPointClick(traceId: string, event?: Event) {

--- a/IsraelHiking.Web/src/application/components/sidebar/layers/layers-sidebar.component.html
+++ b/IsraelHiking.Web/src/application/components/sidebar/layers/layers-sidebar.component.html
@@ -1,6 +1,6 @@
 ﻿<div class="sidebar-header flex flex-row justify-center items-center sticky top-0 z-10 bg-white"
   [dir]="resources.direction">
-  <div class="flex-1 text-center text-xl title">{{resources.layers}}</div>
+  <div class="flex-1 text-center text-xl">{{resources.layers}}</div>
   <button mat-button class="w-1/6" type="button" (click)="close()" tabindex="-1"><i
       class="fa fa-lg icon-close"></i></button>
 </div>

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.ts
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.ts
@@ -155,7 +155,7 @@ export class PublicPoiSidebarComponent implements OnDestroy {
                 await this.initFromFeature(clonedFeature);
             }
             const bounds = SpatialService.getBoundsForFeature(clonedFeature);
-            this.mapService.fitBounds(bounds);
+            this.mapService.fitBounds(bounds, 100, { top: 100, left: 50, bottom: window.innerHeight / 2, right: 50 });
             if (data.source === RouteStrings.COORDINATES) {
                 this.fullFeature = null;
                 this.close();

--- a/IsraelHiking.Web/src/application/services/data-container.service.ts
+++ b/IsraelHiking.Web/src/application/services/data-container.service.ts
@@ -48,7 +48,7 @@ export class DataContainerService {
         }
 
         if (dataContainer.northEast != null && dataContainer.southWest != null) {
-            this.mapService.fitBounds({ northEast: dataContainer.northEast, southWest: dataContainer.southWest }, true);
+            this.mapService.fitBounds({ northEast: dataContainer.northEast, southWest: dataContainer.southWest }, 0);
         }
     }
 

--- a/IsraelHiking.Web/src/application/services/map.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/map.service.spec.ts
@@ -5,7 +5,6 @@ import type { Map, ErrorEvent } from "maplibre-gl";
 import { MapService } from "./map.service";
 import { CancelableTimeoutService } from "./cancelable-timeout.service";
 import { LoggingService } from "./logging.service";
-import { SidebarService } from "./sidebar.service";
 import { ResourcesService } from "./resources.service";
 import { InMemoryReducer } from "../reducers/in-memory.reducer";
 import { SetLocationAction } from "../reducers/location.reducer";
@@ -19,7 +18,6 @@ describe("MapService", () => {
             providers: [
                 MapService,
                 CancelableTimeoutService,
-                { provide: SidebarService, useValue: {} },
                 { provide: ResourcesService, useValue: {} },
                 {
                     provide: LoggingService, useValue: {
@@ -229,34 +227,30 @@ describe("MapService", () => {
         expect(service.isMoving()).toEqual(true);
     }));
 
-    it("Should fit bounds when sidebar serive is open with padding on large screen", inject([MapService, SidebarService],
-        async (service: MapService, sidebarService: SidebarService) => {
-            sidebarService.isSidebarOpen = () => true;
+    it("Should fit bounds with default value when not passed", inject([MapService],
+        async (service: MapService) => {
             const spy = jasmine.createSpy();
             service.setMap({ fitBounds: spy, on: () => { }, getZoom: () => 1 } as any as Map);
-            (window as any).innerWidth = 1500;
             await service.fitBounds({ northEast: { lat: 1, lng: 1 }, southWest: { lat: 2, lng: 2 } });
-            expect(spy.calls.all()[0].args[1].padding.left).toBe(400);
+            expect(spy.calls.all()[0].args[1].padding).toBe(50);
         }
     ));
 
-    it("Should fit bounds when sidebar serive is open with padding on small screen", inject([MapService, SidebarService],
-        async (service: MapService, sidebarService: SidebarService) => {
-            sidebarService.isSidebarOpen = () => true;
+    it("Should fit bounds when with padding on small screen", inject([MapService],
+        async (service: MapService) => {
             const spy = jasmine.createSpy();
             service.setMap({ fitBounds: spy, on: () => { }, getZoom: () => 1 } as any as Map);
             (window as any).innerWidth = 500;
-            await service.fitBounds({ northEast: { lat: 1, lng: 1 }, southWest: { lat: 2, lng: 2 } });
+            await service.fitBounds({ northEast: { lat: 1, lng: 1 }, southWest: { lat: 2, lng: 2 } }, 0, { bottom: window.innerHeight / 2 });
             expect(spy.calls.all()[0].args[1].padding.bottom).toBe(window.innerHeight / 2);
         }
     ));
 
-    it("Should fit bounds when sidebar serive is closed without padding", inject([MapService, SidebarService],
-        async (service: MapService, sidebarService: SidebarService) => {
-            sidebarService.isSidebarOpen = () => false;
+    it("Should fit bounds without padding", inject([MapService],
+        async (service: MapService) => {
             const spy = jasmine.createSpy();
             service.setMap({ fitBounds: spy, on: () => { }, getZoom: () => 1 } as any as Map);
-            await service.fitBounds({ northEast: { lat: 1, lng: 1 }, southWest: { lat: 2, lng: 2 } }, true);
+            await service.fitBounds({ northEast: { lat: 1, lng: 1 }, southWest: { lat: 2, lng: 2 } }, 0);
             expect(spy.calls.all()[0].args[1].padding).toBe(0);
         }
     ));

--- a/IsraelHiking.Web/src/application/services/map.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/map.service.spec.ts
@@ -246,11 +246,11 @@ describe("MapService", () => {
         }
     ));
 
-    it("Should fit bounds without padding", inject([MapService],
+    it("Should fit bounds for large screen and not use the small padding", inject([MapService],
         async (service: MapService) => {
             const spy = jasmine.createSpy();
             service.setMap({ fitBounds: spy, on: () => { }, getZoom: () => 1 } as any as Map);
-            await service.fitBounds({ northEast: { lat: 1, lng: 1 }, southWest: { lat: 2, lng: 2 } }, 0);
+            await service.fitBounds({ northEast: { lat: 1, lng: 1 }, southWest: { lat: 2, lng: 2 } }, 0, { bottom: 100 });
             expect(spy.calls.all()[0].args[1].padding).toBe(0);
         }
     ));

--- a/IsraelHiking.Web/src/application/services/map.service.ts
+++ b/IsraelHiking.Web/src/application/services/map.service.ts
@@ -1,12 +1,11 @@
 import { inject, Injectable } from "@angular/core";
-import { type ErrorEvent, type GeoJSONFeature, type LayerSpecification, type Map, type Point, setRTLTextPlugin, type SourceSpecification, importScriptInWorkers, getGlobalDispatcher } from "maplibre-gl";
+import { type ErrorEvent, type GeoJSONFeature, type LayerSpecification, type Map, type Point, setRTLTextPlugin, type SourceSpecification, importScriptInWorkers, getGlobalDispatcher, type PaddingOptions } from "maplibre-gl";
 import { Store } from "@ngxs/store";
 
 import { CancelableTimeoutService } from "./cancelable-timeout.service";
 import { LoggingService } from "./logging.service";
 import { SetPannedAction } from "../reducers/in-memory.reducer";
 import { SpatialService } from "./spatial.service";
-import { SidebarService } from "./sidebar.service";
 import { ResourcesService } from "./resources.service";
 import { SetLocationAction } from "../reducers/location.reducer";
 import type { ApplicationState, Bounds, LatLngAltTime } from "../models";
@@ -18,7 +17,6 @@ export class MapService {
     private missingImagesArray: string[] = [];
     private currentMap: Map;
 
-    private readonly sidebarService = inject(SidebarService);
     private readonly cancelableTimeoutService = inject(CancelableTimeoutService);
     private readonly loggingService = inject(LoggingService);
     private readonly resourcesService = inject(ResourcesService)
@@ -157,7 +155,7 @@ export class MapService {
         return this.currentMap?.isMoving() ?? false;
     }
 
-    public async fitBounds(bounds: Bounds, noPadding = false) {
+    public async fitBounds(bounds: Bounds, padding = 50, smallScreenPadding?: PaddingOptions) {
         await this.initializationPromise;
         const maxZoom = Math.max(this.currentMap.getZoom(), 16);
         const mbBounds = SpatialService.boundsToMBBounds(bounds);
@@ -165,22 +163,18 @@ export class MapService {
         this.store.dispatch(new SetPannedAction(new Date()));
         this.currentMap.fitBounds(mbBounds, {
             maxZoom,
-            padding: this.getPadding(noPadding)
+            padding: this.getPadding(padding, smallScreenPadding)
         });
     }
 
-    private getPadding(noPadding = false) {
-        let padding = 50;
-        if (noPadding) {
-            padding = 0;
-        }
-        if (!this.sidebarService.isSidebarOpen()) {
+    private getPadding(padding: number, smallScreenPadding?: PaddingOptions) {
+        if (!smallScreenPadding) {
             return padding;
         }
         if (window.innerWidth >= 550) {
-            return { top: 50, left: 400, bottom: 50, right: 50 }
+            return padding;
         }
-        return { top: 50, left: 50, bottom: window.innerHeight / 2, right: 50 }
+        return smallScreenPadding;
     }
 
     public async flyTo(latLng: LatLngAltTime, zoom?: number) {


### PR DESCRIPTION
This removes the popups from cloud saves, traces and public routes and moves to a bottom info window which will not hide the route.
This is only for mobile devices so the popup is removed in desktop completely.
There might be a need to show which one is selected, maybe.

- Fixes #2439