### PR TITLE
Add user filter

### DIFF
--- a/IsraelHiking.Web/src/application/components/image-attribution.component.html
+++ b/IsraelHiking.Web/src/application/components/image-attribution.component.html
@@ -3,13 +3,15 @@
     @if (imageAttribution.userId) {
     <div class="w-full truncate" [dir]="resources.direction">
         {{resources.moreFrom}}
-        <button mat-button (click)="filterByUserId(imageAttribution.userId)">{{imageAttribution.author}}</button>
+        <button mat-button (click)="filterByUserId(imageAttribution.userId)" angulartics2On="click"
+            angulartics2Category="Attribution" angulartics2Label="Filter by user">{{imageAttribution.author}}</button>
     </div>
 
     } @else {
     <div class="w-full truncate" [dir]="resources.direction">
         {{resources.imageBy}}
-        <a [href]="imageAttribution.url" target="_blank">{{imageAttribution.author}}</a>
+        <a [href]="imageAttribution.url" target="_blank" angulartics2On="click" angulartics2Category="Attribution"
+            angulartics2Label="Image Link">{{imageAttribution.author}}</a>
     </div>
     }
 </div>

--- a/IsraelHiking.Web/src/application/components/image-attribution.component.html
+++ b/IsraelHiking.Web/src/application/components/image-attribution.component.html
@@ -2,11 +2,12 @@
 <div class="flex flex-row" class="text-center text-sm">
     @if (imageAttribution.userId) {
     <div class="w-full truncate" [dir]="resources.direction">
-        {{resources.moreFrom}}
-        <button mat-button (click)="filterByUserId(imageAttribution.userId)" angulartics2On="click"
-            angularticsCategory="Attribution" angularticsAction="Filter by user">{{imageAttribution.author}}</button>
+        <button mat-raised-button class="mb-2" (click)="filterByUserId(imageAttribution.userId)" angulartics2On="click"
+            angularticsCategory="Attribution" angularticsAction="Filter by user">
+            {{resources.moreFrom}}
+            {{imageAttribution.author}}
+        </button>
     </div>
-
     } @else {
     <div class="w-full truncate" [dir]="resources.direction">
         {{resources.imageBy}}

--- a/IsraelHiking.Web/src/application/components/image-attribution.component.html
+++ b/IsraelHiking.Web/src/application/components/image-attribution.component.html
@@ -1,7 +1,16 @@
 @if (imageAttribution !== null) {
 <div class="flex flex-row" class="text-center text-sm">
-    <div class="w-full truncate" [dir]="resources.direction">{{resources.imageBy}}
+    @if (imageAttribution.userId) {
+    <div class="w-full truncate" [dir]="resources.direction">
+        {{resources.moreFrom}}
+        <button mat-button (click)="filterByUserId(imageAttribution.userId)">{{imageAttribution.author}}</button>
+    </div>
+
+    } @else {
+    <div class="w-full truncate" [dir]="resources.direction">
+        {{resources.imageBy}}
         <a [href]="imageAttribution.url" target="_blank">{{imageAttribution.author}}</a>
     </div>
+    }
 </div>
 }

--- a/IsraelHiking.Web/src/application/components/image-attribution.component.html
+++ b/IsraelHiking.Web/src/application/components/image-attribution.component.html
@@ -4,14 +4,16 @@
     <div class="w-full truncate" [dir]="resources.direction">
         {{resources.moreFrom}}
         <button mat-button (click)="filterByUserId(imageAttribution.userId)" angulartics2On="click"
-            angulartics2Category="Attribution" angulartics2Label="Filter by user">{{imageAttribution.author}}</button>
+            angularticsCategory="Attribution" angularticsAction="Filter by user">{{imageAttribution.author}}</button>
     </div>
 
     } @else {
     <div class="w-full truncate" [dir]="resources.direction">
         {{resources.imageBy}}
-        <a [href]="imageAttribution.url" target="_blank" angulartics2On="click" angulartics2Category="Attribution"
-            angulartics2Label="Image Link">{{imageAttribution.author}}</a>
+        <a [href]="imageAttribution.url" target="_blank" angulartics2On="click" angularticsCategory="Attribution"
+            angularticsAction="Image Link">
+            {{imageAttribution.author}}
+        </a>
     </div>
     }
 </div>

--- a/IsraelHiking.Web/src/application/components/image-attribution.component.ts
+++ b/IsraelHiking.Web/src/application/components/image-attribution.component.ts
@@ -1,20 +1,28 @@
 import { Component, inject, input, SimpleChanges, OnInit, OnChanges } from "@angular/core";
+import { MatButton } from "@angular/material/button";
+import { Store } from "@ngxs/store";
+
 import { ImageAttribution, ImageAttributionService } from "../services/image-attribution.service";
 import { ResourcesService } from "../services/resources.service";
+import { SetPublicRoutesFilterAction } from "application/reducers/in-memory.reducer";
+import type { ApplicationState, PublicRoutesFilter } from "application/models";
 
 @Component({
     selector: "image-attribution",
-    templateUrl: "./image-attribution.component.html"
+    templateUrl: "./image-attribution.component.html",
+    imports: [MatButton]
 })
 export class ImageAttributionComponent implements OnInit, OnChanges {
 
     public imageUrl = input.required<string>();
+    public allowFiltering = input<boolean>(false);
 
     public imageAttribution: ImageAttribution = null;
 
     public readonly resources = inject(ResourcesService);
 
     private readonly imageAttributionService = inject(ImageAttributionService);
+    private readonly store = inject(Store);
 
     async ngOnInit(): Promise<void> {
         this.imageAttribution = await this.imageAttributionService.getAttributionForImage(this.imageUrl());
@@ -26,5 +34,11 @@ export class ImageAttributionComponent implements OnInit, OnChanges {
         } else {
             this.imageAttribution = null;
         }
+    }
+
+    filterByUserId(userId: string) {
+        const filters = structuredClone(this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter)) as PublicRoutesFilter;
+        filters.userId = userId;
+        this.store.dispatch(new SetPublicRoutesFilterAction(filters));
     }
 }

--- a/IsraelHiking.Web/src/application/components/image-attribution.component.ts
+++ b/IsraelHiking.Web/src/application/components/image-attribution.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, input, SimpleChanges, OnInit, OnChanges } from "@ang
 import { MatButton } from "@angular/material/button";
 import { Store } from "@ngxs/store";
 
+import { Angulartics2OnModule } from "application/directives/gtag.directive";
 import { ImageAttribution, ImageAttributionService } from "../services/image-attribution.service";
 import { ResourcesService } from "../services/resources.service";
 import { SetPublicRoutesFilterAction } from "application/reducers/in-memory.reducer";
@@ -10,7 +11,7 @@ import type { ApplicationState, PublicRoutesFilter } from "application/models";
 @Component({
     selector: "image-attribution",
     templateUrl: "./image-attribution.component.html",
-    imports: [MatButton]
+    imports: [MatButton, Angulartics2OnModule]
 })
 export class ImageAttributionComponent implements OnInit, OnChanges {
 

--- a/IsraelHiking.Web/src/application/components/public-routes-filter.component.html
+++ b/IsraelHiking.Web/src/application/components/public-routes-filter.component.html
@@ -1,4 +1,4 @@
-<div class="flex flex-row items-center">
+<div class="flex flex-row items-center bg-white">
     <span class="mx-2">{{resources.filter}}</span>
     <button mat-button class="flex-1" [matMenuTriggerFor]="listFilterTypeMenu" angulartics2On="click"
         angularticsCategory="Public routes" angularticsAction="Open filter type menu">
@@ -98,3 +98,11 @@
         </div>
     </mat-menu>
 </div>
+@if (filterUserName) {
+<div class="flex flex-row justify-center">
+    <button mat-button class="mx-2 rounded-full! bg-gray-200! p-2" (click)="clearUserFilter()">
+        {{filterUserName}}
+        <i class="fa fa-times mx-2"></i>
+    </button>
+</div>
+}

--- a/IsraelHiking.Web/src/application/components/public-routes-filter.component.ts
+++ b/IsraelHiking.Web/src/application/components/public-routes-filter.component.ts
@@ -7,6 +7,7 @@ import { MatSlider, MatSliderRangeThumb } from "@angular/material/slider";
 import { Store } from "@ngxs/store";
 
 import { ResourcesService } from "../services/resources.service";
+import { ImageAttributionService } from "../services/image-attribution.service";
 import { SetPublicRoutesFilterAction } from "../reducers/in-memory.reducer";
 import { initialState } from "../reducers/initial-state";
 import type { ApplicationState, PublicRoutesFilter } from "../models";
@@ -21,18 +22,22 @@ export class PublicRoutesFilterComponent {
 
     private readonly store = inject(Store);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly imageAttributionService = inject(ImageAttributionService);
 
     public unitString: string = "km";
     public filterLengthStart: number;
     public filterLengthEnd: number;
+    public filterUserName: string;
 
     constructor() {
         this.store.select((state: ApplicationState) => state.configuration.units).pipe(takeUntilDestroyed(this.destroyRef)).subscribe((units) => {
             this.unitString = this.resources.getLongDistanceUnitString(units);
         });
-        const filters = structuredClone(this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter));
-        this.filterLengthStart = filters.lengthRange[0];
-        this.filterLengthEnd = filters.lengthRange[1];
+        this.store.select((state: ApplicationState) => state.inMemoryState.publicRoutesFilter).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async (filters) => {
+            this.filterLengthStart = filters.lengthRange[0];
+            this.filterLengthEnd = filters.lengthRange[1];
+            this.filterUserName = filters.userId ? await this.imageAttributionService.getUserName(filters.userId) : null;
+        });
     }
 
     public onFilterCategoryChange(value: string) {
@@ -91,5 +96,15 @@ export class PublicRoutesFilterComponent {
 
     public isLengthFiltered() {
         return this.filterLengthStart > 0 || this.filterLengthEnd < 50
+    }
+
+    public hasUserFilter() {
+        return this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter.userId) != null;
+    }
+
+    public clearUserFilter() {
+        const filters = structuredClone(this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter)) as PublicRoutesFilter;
+        filters.userId = null;
+        this.store.dispatch(new SetPublicRoutesFilterAction(filters));
     }
 }

--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
@@ -256,7 +256,7 @@
             </div>
             <div class="flex flex-row" class="text-center text-sm">
                 @defer (on viewport) {
-                <image-attribution [imageUrl]="route.properties.image"></image-attribution>
+                <image-attribution [imageUrl]="route.properties.image" [allowFiltering]="true"></image-attribution>
                 } @placeholder {
                 <div></div>
                 }

--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
@@ -14,7 +14,7 @@
         </mat-button-toggle-group>
     </div>
     <div class="w-2/3" [ngClass]="{'max-md:hidden': !showMap, 'max-md:w-full': showMap}">
-        <div class="absolute w-full top-0 magrin-top-with-toolbar z-10 bg-white hidden max-md:block">
+        <div class="absolute w-full top-0 magrin-top-with-toolbar z-10 hidden max-md:block">
             <public-routes-filter></public-routes-filter>
         </div>
         <mgl-map [mapStyle]="mapStyle" [attributionControl]="false" (mapLoad)="mapLoaded($event)">
@@ -185,7 +185,7 @@
     </div>
     <div [ngClass]="{'max-md:hidden': showMap, 'max-md:w-full': !showMap}"
         class="overflow-y-auto z-10 w-1/3 magrin-top-with-toolbar pb-safe-w-button">
-        <div class="sticky top-0 z-10 bg-white">
+        <div class="sticky top-0 z-10">
             <public-routes-filter></public-routes-filter>
         </div>
         @for (route of poiGeoJsonData.features; track route.properties.poiId) {

--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
@@ -29,6 +29,7 @@ import { PoiService } from "../../services/poi.service";
 import { SpatialService } from "../../services/spatial.service";
 import { SelectedRouteService } from "../../services/selected-route.service";
 import { RunningContextService } from "../../services/running-context.service";
+import { ImageAttributionService } from "../../services/image-attribution.service";
 import { GeoJSONUtils } from "../../services/geojson-utils";
 import { PoiProperties } from "../../services/osm-tags.service";
 import { RouteStrings } from "../../services/hash.service";
@@ -69,6 +70,7 @@ export class PublicRoutesComponent {
     private readonly selectedRouteService = inject(SelectedRouteService);
     private readonly router = inject(Router);
     private readonly runningContextSerivce = inject(RunningContextService);
+    private readonly imageAttributionService = inject(ImageAttributionService);
 
     constructor() {
         this.mapStyle = this.defaultStyleService.getStyleWithPlaceholders();
@@ -117,6 +119,9 @@ export class PublicRoutesComponent {
                 return false;
             }
             if (feature.properties.poiLength / factor > filters.lengthRange[1] && filters.lengthRange[1] < 50) {
+                return false;
+            }
+            if (filters.userId && feature.properties.poiUserId !== filters.userId) {
                 return false;
             }
             return true;

--- a/IsraelHiking.Web/src/application/models/public-routes-filter.d.ts
+++ b/IsraelHiking.Web/src/application/models/public-routes-filter.d.ts
@@ -2,4 +2,5 @@ export type PublicRoutesFilter = {
     categories: string[];
     difficulty: string[];
     lengthRange: [number, number];
+    userId: string;
 }

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
@@ -337,4 +337,30 @@ describe("ImageAttributionService", () => {
             expect(response.author).toBe("OSM User");
         }
     ));
+
+    it("should return a OSM user display name when sending a osm id and cache it", inject([ImageAttributionService, HttpTestingController], async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
+        let promise = service.getUserName("12");
+        mockBackend.match(r => r.url.startsWith(`${Urls.osmApi}user/12`))[0].flush({
+            user: {
+                display_name: "Osm User Name"
+            }
+        });
+
+        const response = await promise;
+        expect(response).toBe("Osm User Name");
+
+        promise = service.getUserName("12");
+        mockBackend.expectNone(r => r.url.startsWith(`${Urls.osmApi}user`));
+        const response2 = await promise;
+        expect(response2).toBe("Osm User Name");
+    }));
+
+    it("should return a nakeb for nakeb user id", inject([ImageAttributionService, HttpTestingController], async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
+        const promise = service.getUserName("Nakeb");
+        await new Promise(resolve => setTimeout(resolve, 0));
+        mockBackend.expectNone(r => r.url.startsWith(`${Urls.osmApi}user`));
+
+        const response = await promise;
+        expect(response).toBe("נָאקֶבּ");
+    }));
 });

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
@@ -354,13 +354,4 @@ describe("ImageAttributionService", () => {
         const response2 = await promise;
         expect(response2).toBe("Osm User Name");
     }));
-
-    it("should return a nakeb for nakeb user id", inject([ImageAttributionService, HttpTestingController], async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
-        const promise = service.getUserName("Nakeb");
-        await new Promise(resolve => setTimeout(resolve, 0));
-        mockBackend.expectNone(r => r.url.startsWith(`${Urls.osmApi}user`));
-
-        const response = await promise;
-        expect(response).toBe("נָאקֶבּ");
-    }));
 });

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.spec.ts
@@ -34,6 +34,13 @@ describe("ImageAttributionService", () => {
         expect(response.url).toBe("https://www.example.com");
     }));
 
+    it("should return nakeb when getting it", inject([ImageAttributionService], async (service: ImageAttributionService) => {
+        const response = await service.getAttributionForImage("https://www.nakeb.co.il/image.png");
+        expect(response).not.toBeNull();
+        expect(response.author).toBe("נָאקֶבּ");
+        expect(response.url).toBe("https://www.nakeb.co.il");
+    }));
+
     it("should return a OSM user display name when getting a share url", inject([ImageAttributionService, HttpTestingController], async (service: ImageAttributionService, mockBackend: HttpTestingController) => {
         const promise = service.getAttributionForImage("https://www.mapeak.com/api/urls/12345/thumbnail");
         mockBackend.match(r => r.url.startsWith("https://www.mapeak.com/api/urls/"))[0].flush({

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.ts
@@ -122,8 +122,7 @@ export class ImageAttributionService {
             if ((licenseLower.includes("cc") && !licenseLower.includes("nc")) || licenseLower.includes("public domain")) {
                 return {
                     author: "Unknown",
-                    url: `${wikiPrefix}wiki/File:${imageName}`,
-                    userId: null
+                    url: `${wikiPrefix}wiki/File:${imageName}`
                 };
             }
         } catch { } // eslint-disable-line

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.ts
@@ -8,6 +8,7 @@ import type { OsmUserDetails, ShareUrl } from "../models";
 export type ImageAttribution = {
     author: string;
     url: string;
+    userId?: string;
 };
 
 @Injectable()
@@ -58,11 +59,21 @@ export class ImageAttributionService {
         if (!url.hostname && !wikidataFileUrl) {
             return null;
         }
+        if (url.hostname.includes("nakeb")) {
+            const imageAttribution = {
+                author: "נָאקֶבּ",
+                url: "https://www.nakeb.co.il",
+                userId: "Nakeb"
+            };
+            this.attributionImageCache.set(imageUrl, Promise.resolve(imageAttribution));
+            return imageAttribution;
+        }
         if (url.hostname.includes("mapeak.com")) {
             const shareUrl = await firstValueFrom(this.httpClient.get<ShareUrl>(imageUrl.replace("/thumbnail", "")));
             const imageAttribution = {
                 author: await this.getUserName(shareUrl.osmUserId),
-                url: shareUrl.website
+                url: shareUrl.website,
+                userId: shareUrl.osmUserId
             };
             this.attributionImageCache.set(imageUrl, Promise.resolve(imageAttribution));
             return imageAttribution;
@@ -111,7 +122,8 @@ export class ImageAttributionService {
             if ((licenseLower.includes("cc") && !licenseLower.includes("nc")) || licenseLower.includes("public domain")) {
                 return {
                     author: "Unknown",
-                    url: `${wikiPrefix}wiki/File:${imageName}`
+                    url: `${wikiPrefix}wiki/File:${imageName}`,
+                    userId: null
                 };
             }
         } catch { } // eslint-disable-line

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.ts
@@ -13,6 +13,7 @@ export type ImageAttribution = {
 @Injectable()
 export class ImageAttributionService {
     private attributionImageCache = new Map<string, Promise<ImageAttribution>>();
+    private userIdToNameCache = new Map<string, string>();
 
     private readonly httpClient = inject(HttpClient);
 
@@ -59,9 +60,8 @@ export class ImageAttributionService {
         }
         if (url.hostname.includes("mapeak.com")) {
             const shareUrl = await firstValueFrom(this.httpClient.get<ShareUrl>(imageUrl.replace("/thumbnail", "")));
-            const osmUser = await firstValueFrom(this.httpClient.get<OsmUserDetails>(`${Urls.osmApi}user/${shareUrl.osmUserId}`));
             const imageAttribution = {
-                author: osmUser.user.display_name,
+                author: await this.getUserName(shareUrl.osmUserId),
                 url: shareUrl.website
             };
             this.attributionImageCache.set(imageUrl, Promise.resolve(imageAttribution));
@@ -116,5 +116,14 @@ export class ImageAttributionService {
             }
         } catch { } // eslint-disable-line
         return null;
+    }
+
+    public async getUserName(userId: string): Promise<string> {
+        if (this.userIdToNameCache.has(userId)) {
+            return this.userIdToNameCache.get(userId);
+        }
+        const osmUser = await firstValueFrom(this.httpClient.get<OsmUserDetails>(`${Urls.osmApi}user/${userId}`));
+        this.userIdToNameCache.set(userId, osmUser.user.display_name);
+        return osmUser.user.display_name;
     }
 }

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.ts
@@ -60,10 +60,11 @@ export class ImageAttributionService {
             return null;
         }
         if (url.hostname.includes("nakeb")) {
+            const userId = "Nakeb";
             const imageAttribution = {
-                author: "נָאקֶבּ",
+                author: await this.getUserName(userId),
                 url: "https://www.nakeb.co.il",
-                userId: "Nakeb"
+                userId
             };
             this.attributionImageCache.set(imageUrl, Promise.resolve(imageAttribution));
             return imageAttribution;

--- a/IsraelHiking.Web/src/application/services/image-attribution.service.ts
+++ b/IsraelHiking.Web/src/application/services/image-attribution.service.ts
@@ -134,6 +134,9 @@ export class ImageAttributionService {
         if (this.userIdToNameCache.has(userId)) {
             return this.userIdToNameCache.get(userId);
         }
+        if (userId === "Nakeb") {
+            return "נָאקֶבּ";
+        }
         const osmUser = await firstValueFrom(this.httpClient.get<OsmUserDetails>(`${Urls.osmApi}user/${userId}`));
         this.userIdToNameCache.set(userId, osmUser.user.display_name);
         return osmUser.user.display_name;

--- a/IsraelHiking.Web/src/application/services/osm-tags.service.ts
+++ b/IsraelHiking.Web/src/application/services/osm-tags.service.ts
@@ -10,6 +10,7 @@ export type PoiProperties = {
     poiCategory: string;
     poiLength: number;
     poiDifficulty: string;
+    poiUserId?: string;
     "name:he"?: string;
     "name:en"?: string;
     website: string;

--- a/IsraelHiking.Web/src/application/services/poi.service.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.ts
@@ -389,6 +389,7 @@ export class PoiService {
                 poiDifficulty: shareUrl.difficulty,
                 poiGeolocation: geoLocation,
                 poiId: "Users_" + shareUrl.id,
+                poiUserId: shareUrl.osmUserId,
                 identifier: shareUrl.id,
                 name: shareUrl.title,
                 description: shareUrl.description,

--- a/IsraelHiking.Web/src/application/services/resources.service.ts
+++ b/IsraelHiking.Web/src/application/services/resources.service.ts
@@ -288,6 +288,7 @@ export class ResourcesService {
     public metric: string;
     public imperial: string;
     public dateFormat: string;
+    public moreFrom: string;
     // Toasts: Errors/Warnings/Success
     public unableToGetSearchResults: string;
     public pleaseSelectFrom: string;
@@ -509,7 +510,7 @@ export class ResourcesService {
     }
 
     private async setLanguageInternal(language: Language): Promise<void> {
-        await this.gettextCatalog.loadRemote(Urls.translations + language.code + ".json?sign=1775507616257");
+        await this.gettextCatalog.loadRemote(Urls.translations + language.code + ".json?sign=1776597953833");
         this.about = this.gettextCatalog.getString("About");
         this.legend = this.gettextCatalog.getString("Legend");
         this.clear = this.gettextCatalog.getString("Clear");
@@ -775,6 +776,7 @@ export class ResourcesService {
         this.metric = this.gettextCatalog.getString("Metric");
         this.imperial = this.gettextCatalog.getString("Imperial");
         this.dateFormat = this.gettextCatalog.getString("Date Format");
+        this.moreFrom = this.gettextCatalog.getString("More from");
         // Toasts: Errors/Warnings/Success
         this.unableToGetSearchResults = this.gettextCatalog.getString("Unable to get search results...");
         this.pleaseSelectFrom = this.gettextCatalog.getString("Please select from...");

--- a/IsraelHiking.Web/src/translations/ar.json
+++ b/IsraelHiking.Web/src/translations/ar.json
@@ -228,6 +228,7 @@
     "Minefield": "حقل ألغام",
     "Minimize": "تصغير",
     "Moderate": "معتدل",
+    "More from": "المزيد من",
     "More Info...": "معلومات إضافية...",
     "More map addresses can be found here, look for TMS": "يمكن العثور على عناوين خرائط إضافية هنا، ابحث عن TMS",
     "More...": "المزيد...",

--- a/IsraelHiking.Web/src/translations/en-US.json
+++ b/IsraelHiking.Web/src/translations/en-US.json
@@ -228,6 +228,7 @@
     "Minefield": "Minefield",
     "Minimize": "Minimize",
     "Moderate": "Moderate",
+    "More from": "More from",
     "More Info...": "More Info...",
     "More map addresses can be found here, look for TMS": "More map addresses can be found here, look for TMS",
     "More...": "More...",

--- a/IsraelHiking.Web/src/translations/he.json
+++ b/IsraelHiking.Web/src/translations/he.json
@@ -228,6 +228,7 @@
     "Minefield": "שדה מוקשים",
     "Minimize": "מזעור",
     "Moderate": "בינוני",
+    "More from": "עוד מאת",
     "More Info...": "עוד מידע...",
     "More map addresses can be found here, look for TMS": "כתובות מפה נוספות נמצאות כאן, חפשו TMS",
     "More...": "עוד...",

--- a/IsraelHiking.Web/src/translations/ru.json
+++ b/IsraelHiking.Web/src/translations/ru.json
@@ -228,6 +228,7 @@
     "Minefield": "Минное поле",
     "Minimize": "Минимизировать",
     "Moderate": "Умеренный",
+    "More from": "Больше от",
     "More Info...": "Больше информации...",
     "More map addresses can be found here, look for TMS": "Дополнительные адреса карт можно найти здесь.",
     "More...": "Больше...",


### PR DESCRIPTION
- Resolves #2458

This changes the attribution for public routes to allow filtering by a specific user.
This is only valid for non OSM routes, as this information is not available in OSM for the routes from OSM.
This is a minor addition to the Filtering UI which I hope can facilitate for most of the needed use cases.


