### PR TITLE
Add POI list along route with map centering

### DIFF
--- a/IsraelHiking.API/Controllers/PointsOfInterestController.cs
+++ b/IsraelHiking.API/Controllers/PointsOfInterestController.cs
@@ -4,6 +4,7 @@ using IsraelHiking.API.Services.Poi;
 using IsraelHiking.Common;
 using IsraelHiking.Common.Api;
 using IsraelHiking.Common.Extensions;
+using IsraelHiking.Common.Poi;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
@@ -185,6 +186,24 @@ public class PointsOfInterestController : ControllerBase
     public Task<IFeature> GetClosestPoint(string location, string source, string language)
     {
         return _pointsOfInterestProvider.GetClosestPoint(location.ToCoordinate(), source, language);
+    }
+
+    /// <summary>
+    /// Returns POIs along the given route, sorted by km-from-start.
+    /// </summary>
+    /// <param name="coordinates">Ordered list of route coordinates (lat/lng)</param>
+    /// <param name="bufferMeters">Search corridor half-width in metres (default 500)</param>
+    /// <param name="language">UI language code</param>
+    /// <returns></returns>
+    [HttpPost]
+    [Route("along-route")]
+    public async Task<IActionResult> GetPoisAlongRoute(
+        [FromBody] LatLng[] coordinates,
+        [FromQuery] double bufferMeters = 500,
+        [FromQuery] string language = "")
+    {
+        var results = await _pointsOfInterestProvider.GetPoisAlongRoute(coordinates, bufferMeters, language);
+        return Ok(results);
     }
 
     /// <summary>

--- a/IsraelHiking.API/Services/Poi/IPointsOfInterestProvider.cs
+++ b/IsraelHiking.API/Services/Poi/IPointsOfInterestProvider.cs
@@ -1,6 +1,9 @@
-﻿using NetTopologySuite.Features;
+﻿using IsraelHiking.Common;
+using IsraelHiking.Common.Poi;
+using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using OsmSharp.IO.API;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace IsraelHiking.API.Services.Poi;
@@ -45,4 +48,13 @@ public interface IPointsOfInterestProvider
     /// <param name="language"></param>
     /// <returns></returns>
     public Task<IFeature> GetClosestPoint(Coordinate location, string source, string language);
+
+    /// <summary>
+    /// Returns POIs within bufferMeters of the given route, sorted by distance from start.
+    /// </summary>
+    /// <param name="coordinates">Ordered route coordinates (lat/lng)</param>
+    /// <param name="bufferMeters">Search corridor width in metres</param>
+    /// <param name="language">UI language code</param>
+    /// <returns></returns>
+    Task<List<RoutePoiItem>> GetPoisAlongRoute(LatLng[] coordinates, double bufferMeters, string language);
 }

--- a/IsraelHiking.API/Services/Poi/PointsOfInterestProvider.cs
+++ b/IsraelHiking.API/Services/Poi/PointsOfInterestProvider.cs
@@ -3,11 +3,13 @@ using IsraelHiking.API.Executors;
 using IsraelHiking.API.Services.Osm;
 using IsraelHiking.Common;
 using IsraelHiking.Common.Extensions;
+using IsraelHiking.Common.Poi;
 using IsraelHiking.DataAccessInterfaces;
 using IsraelHiking.DataAccessInterfaces.Repositories;
 using Microsoft.Extensions.Logging;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.LinearReferencing;
 using OsmSharp;
 using OsmSharp.Complete;
 using OsmSharp.IO.API;
@@ -460,5 +462,111 @@ public class PointsOfInterestProvider : IPointsOfInterestProvider
         var wikiImageUrl = await _wikimediaCommonGateway.UploadImage(file.FileName, nonEmptyDescription, userDisplayName, memoryStream, feature.GetLocation());
         await _imageUrlStoreExecutor.StoreImage(md5, file.Content, wikiImageUrl);
         return wikiImageUrl;
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<RoutePoiItem>> GetPoisAlongRoute(LatLng[] coordinates, double bufferMeters, string language)
+    {
+        if (coordinates == null || coordinates.Length < 2)
+        {
+            return [];
+        }
+
+        var routeCoords = coordinates.Select(c => new Coordinate(c.Lng, c.Lat)).ToArray();
+        var bufferDegrees = bufferMeters / 111000.0;
+
+        var minLon = routeCoords.Min(c => c.X) - bufferDegrees;
+        var maxLon = routeCoords.Max(c => c.X) + bufferDegrees;
+        var minLat = routeCoords.Min(c => c.Y) - bufferDegrees;
+        var maxLat = routeCoords.Max(c => c.Y) + bufferDegrees;
+
+        var features = await _pointsOfInterestRepository.GetPoisWithinBoundingBox(
+            new Coordinate(minLon, maxLat),
+            new Coordinate(maxLon, minLat),
+            language);
+
+        var line = new LineString(routeCoords);
+        var lil = new LengthIndexedLine(line);
+
+        var results = new List<RoutePoiItem>();
+        foreach (var feature in features)
+        {
+            var title = feature.GetTitle(language);
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                continue;
+            }
+
+            var poiCoord = feature.Geometry.Coordinate;
+            var distanceDegrees = line.Distance(new Point(poiCoord));
+            var distanceMeters = distanceDegrees * 111000.0;
+
+            if (distanceMeters > bufferMeters)
+            {
+                continue;
+            }
+
+            var projIndex = lil.IndexOf(poiCoord);
+            var distanceFromStartKm = ComputeDistanceAlongRouteKm(routeCoords, projIndex);
+
+            var location = feature.GetLocation();
+            results.Add(new RoutePoiItem
+            {
+                Poi = new SearchResultsPointOfInterest
+                {
+                    Id = feature.Attributes[FeatureAttributes.ID].ToString(),
+                    Source = feature.Attributes[FeatureAttributes.POI_SOURCE].ToString(),
+                    Title = title,
+                    DisplayName = title,
+                    Icon = feature.Attributes[FeatureAttributes.POI_ICON].ToString(),
+                    IconColor = feature.Attributes[FeatureAttributes.POI_ICON_COLOR].ToString(),
+                    Location = new LatLng(location.Y, location.X),
+                    HasExtraData = feature.HasExtraData(language)
+                },
+                DistanceFromStartKm = Math.Round(distanceFromStartKm, 2),
+                DistanceFromRouteMeters = Math.Round(distanceMeters, 0),
+                Description = feature.GetDescription(language)
+            });
+        }
+
+        return [.. results.OrderBy(r => r.DistanceFromStartKm)];
+    }
+
+    private static double ComputeDistanceAlongRouteKm(Coordinate[] routeCoords, double projIndex)
+    {
+        double cumulativeEuclidean = 0;
+        double cumulativeHaversineKm = 0;
+
+        for (int i = 0; i < routeCoords.Length - 1; i++)
+        {
+            double segEuclidean = routeCoords[i].Distance(routeCoords[i + 1]);
+            double segHaversineKm = HaversineKm(
+                routeCoords[i].Y, routeCoords[i].X,
+                routeCoords[i + 1].Y, routeCoords[i + 1].X);
+
+            if (cumulativeEuclidean + segEuclidean >= projIndex)
+            {
+                double fraction = segEuclidean > 0
+                    ? (projIndex - cumulativeEuclidean) / segEuclidean
+                    : 0;
+                return cumulativeHaversineKm + fraction * segHaversineKm;
+            }
+
+            cumulativeEuclidean += segEuclidean;
+            cumulativeHaversineKm += segHaversineKm;
+        }
+
+        return cumulativeHaversineKm;
+    }
+
+    private static double HaversineKm(double lat1, double lon1, double lat2, double lon2)
+    {
+        const double R = 6371.0;
+        var dLat = (lat2 - lat1) * Math.PI / 180.0;
+        var dLon = (lon2 - lon1) * Math.PI / 180.0;
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+                Math.Cos(lat1 * Math.PI / 180.0) * Math.Cos(lat2 * Math.PI / 180.0) *
+                Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        return R * 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
     }
 }

--- a/IsraelHiking.Common/Poi/RoutePoiItem.cs
+++ b/IsraelHiking.Common/Poi/RoutePoiItem.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace IsraelHiking.Common.Poi;
+
+public class RoutePoiItem
+{
+    [JsonPropertyName("poi")]
+    public SearchResultsPointOfInterest Poi { get; set; }
+
+    [JsonPropertyName("distanceFromStartKm")]
+    public double DistanceFromStartKm { get; set; }
+
+    [JsonPropertyName("distanceFromRouteMeters")]
+    public double DistanceFromRouteMeters { get; set; }
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; }
+}

--- a/IsraelHiking.DataAccess/ElasticSearch/ElasticSearchGateway.cs
+++ b/IsraelHiking.DataAccess/ElasticSearch/ElasticSearchGateway.cs
@@ -366,6 +366,22 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
 
     }
 
+    public async Task<List<IFeature>> GetPoisWithinBoundingBox(Coordinate topLeft, Coordinate bottomRight, string language)
+    {
+        var response = await _elasticClient.SearchAsync<PointDocument>(s =>
+            s.Index(POINTS)
+            .Size(500)
+            .Query(q =>
+                q.GeoBoundingBox(b => b.BoundingBox(
+                        bb => bb.TopLeft(new GeoCoordinate(topLeft.Y, topLeft.X))
+                            .BottomRight(new GeoCoordinate(bottomRight.Y, bottomRight.X))
+                    ).Field(p => p.Location))
+                && q.Bool(b => b.MustNot(mn => mn.Term(t => t.Field(p => p.PoiIcon).Value("icon-search"))))
+            )
+        );
+        return response.Hits.Select(d => HitToFeature(d, language ?? Languages.DEFAULT)).ToList();
+    }
+
     public async Task<List<IFeature>> GetAllPointsOfInterest()
     {
         await _elasticClient.Indices.RefreshAsync(POINTS);

--- a/IsraelHiking.DataAccessInterfaces/Repositories/IPointsOfInterestRepository.cs
+++ b/IsraelHiking.DataAccessInterfaces/Repositories/IPointsOfInterestRepository.cs
@@ -10,5 +10,6 @@ public interface IPointsOfInterestRepository
 {
     Task<IFeature> GetClosestPoint(Coordinate location, string source, string language);
     Task<List<IFeature>> GetAllPointsOfInterest();
+    Task<List<IFeature>> GetPoisWithinBoundingBox(Coordinate topLeft, Coordinate bottomRight, string language);
     Task StoreRebuildContext(RebuildContext context);
 }

--- a/IsraelHiking.Web/src/application/components/route-statistics.component.html
+++ b/IsraelHiking.Web/src/application/components/route-statistics.component.html
@@ -3,7 +3,35 @@
   @if (isOpen()) {
   <div animate.enter="chart-enter" animate.leave="chart-leave" class="chart-control-container chart-animated"
     [class.expanded]="isExpanded" [class.sidebar]="isSidebarVisible()">
-    @if (isTable) {
+    @if (isPois) {
+    <div class="chart-container overflow-y-auto">
+      @if (isPoisLoading) {
+      <div class="flex items-center justify-center h-full">
+        <i class="fa icon-spinner fa-spin fa-2x"></i>
+      </div>
+      } @else if (routePois.length === 0) {
+      <div class="flex items-center justify-center h-full text-gray-500 text-sm p-4">
+        <span>No POIs found along this route</span>
+      </div>
+      } @else {
+      <div class="flex flex-col gap-1 p-2">
+        @for (item of routePois; track item.poi.id) {
+        <div class="flex flex-row items-start gap-2 p-1 border-b border-gray-200 cursor-pointer hover:bg-gray-100 active:bg-gray-200"
+          (click)="flyToPoiLocation(item)">
+          <i class="fa {{item.poi.icon}} mt-1 text-base" [style.color]="item.poi.iconColor"></i>
+          <div class="flex flex-col min-w-0 flex-1">
+            <span class="font-semibold text-sm truncate">{{item.poi.title}}</span>
+            @if (item.description) {
+            <span class="text-xs text-gray-600 line-clamp-2">{{item.description}}</span>
+            }
+          </div>
+          <span class="text-xs text-gray-500 whitespace-nowrap">{{item.distanceFromStartKm | number:'1.1-1'}} km</span>
+        </div>
+        }
+      </div>
+      }
+    </div>
+    } @else if (isTable) {
     <div class="chart-container">
       <mat-grid-list cols="3" rowHeight="fit" class="chart-table">
         @if (!isFollowing) {
@@ -101,18 +129,21 @@
     }
     <div class="absolute start-0 bottom-0 flex flex-col m-1">
       @if (!isExpanded) {
-      <button mat-button (click)="changeState('table')" [class.active]="isTable" analyticsOn="click"
+      <button mat-button (click)="changeState('table')" [class.active]="isTable && !isPois" analyticsOn="click"
         analyticsCategory="Route statistics" analyticsLabel="Toggle table view"><i
           class="fa icon-table fa-lg"></i></button>
       }
-      <button mat-button (click)="changeState('graph')" [class.active]="!isTable" analyticsOn="click"
+      <button mat-button (click)="changeState('graph')" [class.active]="!isTable && !isPois" analyticsOn="click"
         analyticsCategory="Route statistics" analyticsLabel="Toggle graph view"><i
           class="fa icon-area-chart fa-lg"></i></button>
+      <button mat-button (click)="changeState('pois')" [class.active]="isPois" analyticsOn="click"
+        analyticsCategory="Route statistics" analyticsLabel="Toggle POIs view"><i
+          class="fa icon-map-marker fa-lg"></i></button>
     </div>
     <div class="absolute top-0 end-0 flex flex-col">
       <button mat-button class="m-1" (click)="toggle()" analyticsCategory="Route statistics"
         analyticsLabel="Route statistics close"><i class="fa icon-close fa-lg"></i></button>
-      @if (!isTable) {
+      @if (!isTable && !isPois) {
       <button mat-button class="m-1 max-sm:hidden!" (click)="toggleExpand()" analyticsOn="click"
         analyticsCategory="Route statistics" analyticsLabel="Toggle expand view"><i class="fa fa-lg"
           [ngClass]="{ 'icon-chevron-right' : isExpanded && resources.end === 'left' || !isExpanded && resources.end === 'right', 'icon-chevron-left' : !isExpanded && resources.end === 'left' || isExpanded && resources.end === 'right'}"></i></button>
@@ -229,6 +260,15 @@
 <mgl-layer id="chart-hover-layer" type="circle" source="chart-hover" [paint]="{
           'circle-color': ['get', 'color'],
           'circle-radius': 7,
+          'circle-stroke-color': 'white',
+          'circle-stroke-width': 3
+          }">
+</mgl-layer>
+
+<mgl-geojson-source id="selected-poi" [data]="selectedPoiSource"></mgl-geojson-source>
+<mgl-layer id="selected-poi-layer" type="circle" source="selected-poi" [paint]="{
+          'circle-color': '#e53e3e',
+          'circle-radius': 9,
           'circle-stroke-color': 'white',
           'circle-stroke-width': 3
           }">

--- a/IsraelHiking.Web/src/application/components/route-statistics.component.ts
+++ b/IsraelHiking.Web/src/application/components/route-statistics.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation, OnInit, ElementRef, ChangeDetectorRef, DestroyRef, inject, viewChild, signal } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { NgClass } from "@angular/common";
+import { NgClass, DecimalPipe } from "@angular/common";
 import { Dir } from "@angular/cdk/bidi";
 import { MatGridList, MatGridTile } from "@angular/material/grid-list";
 import { MatTooltip } from "@angular/material/tooltip";
@@ -24,8 +24,10 @@ import { CancelableTimeoutService } from "../services/cancelable-timeout.service
 import { SidebarService } from "../services/sidebar.service";
 import { SpatialService } from "../services/spatial.service";
 import { GeoLocationService } from "../services/geo-location.service";
+import { PoiService } from "../services/poi.service";
+import { MapService } from "../services/map.service";
 import { ToggleIsShowKmMarkersAction, ToggleIsShowSlopeAction } from "../reducers/configuration.reducer";
-import type { LatLngAltTime, ApplicationState } from "../models";
+import type { LatLngAltTime, ApplicationState, RoutePoiItem } from "../models";
 
 declare type DragState = "start" | "drag" | "none";
 
@@ -66,7 +68,7 @@ interface IChartElements {
     templateUrl: "./route-statistics.component.html",
     styleUrls: ["./route-statistics.component.scss"],
     encapsulation: ViewEncapsulation.None,
-    imports: [Dir, NgClass, MatGridList, MatGridTile, MatTooltip, MatButton, AnalyticsDirective, MatMenu, MatMenuItem, MatMenuTrigger, SourceDirective, GeoJSONSourceComponent, LayerComponent, DistancePipe]
+    imports: [Dir, NgClass, DecimalPipe, MatGridList, MatGridTile, MatTooltip, MatButton, AnalyticsDirective, MatMenu, MatMenuItem, MatMenuTrigger, SourceDirective, GeoJSONSourceComponent, LayerComponent, DistancePipe]
 })
 export class RouteStatisticsComponent implements OnInit {
     private static readonly HOVER_BOX_WIDTH = 110;
@@ -87,6 +89,10 @@ export class RouteStatisticsComponent implements OnInit {
     public isSlopeOn: boolean = false;
     public isExpanded: boolean = false;
     public isTable: boolean = false;
+    public isPois: boolean = false;
+    public isPoisLoading: boolean = false;
+    public routePois: RoutePoiItem[] = [];
+    public selectedPoiSource: GeoJSON.FeatureCollection<GeoJSON.Point> = { type: "FeatureCollection", features: [] };
     public isOpen = signal(false);
     public isFollowing: boolean = false;
     public isVisible: boolean = false;
@@ -122,6 +128,8 @@ export class RouteStatisticsComponent implements OnInit {
     private readonly routeStatisticsService = inject(RouteStatisticsService);
     private readonly cancelableTimeoutService = inject(CancelableTimeoutService);
     private readonly sidebarService = inject(SidebarService);
+    private readonly poiService = inject(PoiService);
+    private readonly mapService = inject(MapService);
     private readonly store = inject(Store);
     private readonly destroyRef = inject(DestroyRef);
 
@@ -252,20 +260,62 @@ export class RouteStatisticsComponent implements OnInit {
     public changeState(state: string) {
         switch (state) {
             case "table":
-                if (this.isTable) {
+                if (this.isTable && !this.isPois) {
                     this.toggle();
                 } else {
                     this.isTable = true;
+                    this.isPois = false;
                 }
                 break;
             case "graph":
-                if (!this.isTable) {
+                if (!this.isTable && !this.isPois) {
                     this.toggle();
                 } else {
                     this.isTable = false;
+                    this.isPois = false;
                     this.redrawChart();
                 }
+                break;
+            case "pois":
+                if (this.isPois) {
+                    this.toggle();
+                } else {
+                    this.isPois = true;
+                    this.isTable = false;
+                    this.loadPois();
+                }
         }
+    }
+
+    public async loadPois() {
+        const route = this.getRouteForChart();
+        if (!route || route.latlngs.length === 0) {
+            this.routePois = [];
+            return;
+        }
+        this.isPoisLoading = true;
+        this.routePois = [];
+        try {
+            const language = this.store.selectSnapshot((s: ApplicationState) => s.configuration.language.code);
+            const latlngs = [...route.latlngs] as LatLngAltTime[];
+            this.routePois = await this.poiService.getPoisAlongRoute(latlngs, 500, language);
+        } catch {
+            this.routePois = [];
+        } finally {
+            this.isPoisLoading = false;
+        }
+    }
+
+    public flyToPoiLocation(item: RoutePoiItem) {
+        this.mapService.flyTo(item.poi.location);
+        this.selectedPoiSource = {
+            type: "FeatureCollection",
+            features: [{
+                type: "Feature",
+                properties: {},
+                geometry: { type: "Point", coordinates: [item.poi.location.lng, item.poi.location.lat] }
+            }]
+        };
     }
 
     public isSidebarVisible() {
@@ -278,6 +328,7 @@ export class RouteStatisticsComponent implements OnInit {
             this.redrawChart();
         } else {
             this.clearSubRouteSelection();
+            this.selectedPoiSource = { type: "FeatureCollection", features: [] };
         }
     }
 

--- a/IsraelHiking.Web/src/application/models/index.d.ts
+++ b/IsraelHiking.Web/src/application/models/index.d.ts
@@ -20,7 +20,7 @@ export type { EditableLayer } from "./editable-layer.js";
 export type { Trace, TraceVisibility } from "./trace";
 export type { OsmUserDetails } from "./osm-user-details";
 export type { UserInfo } from "./user-info";
-export type { SearchResultsPointOfInterest, EditablePublicPointData, UpdateablePublicPointData as UpdateablePublicPoiData } from "./point-of-interest";
+export type { SearchResultsPointOfInterest, EditablePublicPointData, UpdateablePublicPointData as UpdateablePublicPoiData, RoutePoiItem } from "./point-of-interest";
 export type { NorthEast } from "./north-east";
 export type { CategoriesGroup, Category, IconColorLabel, CategoriesGroupType } from "./categories-group";
 export type { Language, LanguageCode } from "./language";

--- a/IsraelHiking.Web/src/application/models/point-of-interest.d.ts
+++ b/IsraelHiking.Web/src/application/models/point-of-interest.d.ts
@@ -30,3 +30,10 @@ export type EditablePublicPointData = UpdateablePublicPointData & {
     location: LatLngAlt;
     originalFeature: Immutable<GeoJSON.Feature>;
 };
+
+export type RoutePoiItem = {
+    poi: SearchResultsPointOfInterest;
+    distanceFromStartKm: number;
+    distanceFromRouteMeters: number;
+    description: string;
+};

--- a/IsraelHiking.Web/src/application/services/poi.service.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.ts
@@ -35,7 +35,8 @@ import type {
     NorthEast,
     EditablePublicPointData,
     UpdateablePublicPoiData,
-    ShareUrl
+    ShareUrl,
+    RoutePoiItem
 } from "../models";
 
 export type SimplePointType = "Tap" | "CattleGrid" | "Parking" | "OpenGate" | "ClosedGate" | "Block" | "PicnicSite" | "Bench"
@@ -544,6 +545,14 @@ export class PoiService {
             this.loggingService.warning(`[POIs] Unable to get closest POI: ${(ex as Error).message}`);
         }
         return null;
+    }
+
+    public async getPoisAlongRoute(latlngs: LatLngAltTime[], bufferMeters: number, language: string): Promise<RoutePoiItem[]> {
+        const params = new HttpParams()
+            .set("bufferMeters", bufferMeters.toString())
+            .set("language", language);
+        const url = `${Urls.poisAlongRoute}?${params.toString()}`;
+        return firstValueFrom(this.httpClient.post<RoutePoiItem[]>(url, latlngs));
     }
 
     public addSimplePoint(latlng: LatLngAltTime, pointType: SimplePointType, id: string): Promise<any> {

--- a/IsraelHiking.Web/src/application/urls.ts
+++ b/IsraelHiking.Web/src/application/urls.ts
@@ -22,6 +22,7 @@ export class Urls {
     public static readonly poiClosest = Urls.poi + "closest/";
     public static readonly poiUpdates = Urls.poi + "updates/";
     public static readonly poiSimple = Urls.poi + "simple/";
+    public static readonly poisAlongRoute = Urls.poi + "along-route";
 
     public static readonly urls = Urls.apiBase + "urls/";
     public static readonly userLayers = Urls.apiBase + "userLayers/";


### PR DESCRIPTION
Add POIs along route with map centering

Show a list of interesting points of interest (POIs) that lie within
500m of a loaded route, sorted by distance from the start.

User story:
  As a hiker planning or following a route,
  I want to see which POIs (water sources, cafes, viewpoints, ruins, etc.)
  are close to my route and how far along I will reach them,
  so I can plan stops, water refills, and points of interest in advance.

Changes:
- Backend: new GET bbox query on the Elasticsearch points index,
  new GetPoisAlongRoute service method using NTS LineString projection
  and Haversine km-from-start calculation, new POST /api/points/along-route
  endpoint accepting an array of coordinates with a configurable buffer
- Frontend: third view in the route-statistics panel (map-marker button)
  showing a scrollable POI list with icon, name, description, and km marker;
  clicking a row flies the map to that POI and shows a red dot on the map