### PR TITLE
Include routes without images

### DIFF
--- a/IsraelHiking.Web/src/application/components/map/main-map.component.ts
+++ b/IsraelHiking.Web/src/application/components/map/main-map.component.ts
@@ -163,7 +163,7 @@ export class MainMapComponent {
         this.isTerrainOn = true;
         const source: RasterDEMSourceSpecification = {
             type: "raster-dem",
-            tiles: ["slice://global.israelhikingmap.workers.dev/jaxa_terrarium0-11_v2/{z}/{x}/{y}.webp"],
+            tiles: ["https://global.israelhikingmap.workers.dev/jaxa_terrarium0-11_v2/{z}/{x}/{y}.webp"],
             minzoom: 7,
             maxzoom: 11,
             tileSize: 512,

--- a/IsraelHiking.Web/src/application/components/map/public-pois.component.ts
+++ b/IsraelHiking.Web/src/application/components/map/public-pois.component.ts
@@ -109,9 +109,7 @@ export class PublicPoisComponent implements OnInit {
             return;
         }
         const sourceAndId = this.getSourceAndId(this.poiService.getFeatureId(feature));
-        this.router.navigate([RouteStrings.ROUTE_POI, sourceAndId.source, sourceAndId.id],
-            { queryParams: { language: this.resources.getCurrentLanguageCodeSimplified() } });
-
+        this.router.navigate([RouteStrings.ROUTE_POI, sourceAndId.source, sourceAndId.id]);
     }
 
     public async toggleClusterPopup(event: MouseEvent, feature: GeoJSON.Feature<GeoJSON.Point>, sourceComponent: GeoJSONSourceComponent) {

--- a/IsraelHiking.Web/src/application/components/public-routes-filter.component.ts
+++ b/IsraelHiking.Web/src/application/components/public-routes-filter.component.ts
@@ -10,7 +10,7 @@ import { ResourcesService } from "../services/resources.service";
 import { ImageAttributionService } from "../services/image-attribution.service";
 import { SetPublicRoutesFilterAction } from "../reducers/in-memory.reducer";
 import { initialState } from "../reducers/initial-state";
-import type { ApplicationState, PublicRoutesFilter } from "../models";
+import type { ApplicationState, CategoryType, Difficulty, PublicRoutesFilter } from "../models";
 
 @Component({
     selector: "public-routes-filter",
@@ -40,7 +40,7 @@ export class PublicRoutesFilterComponent {
         });
     }
 
-    public onFilterCategoryChange(value: string) {
+    public onFilterCategoryChange(value: CategoryType) {
         const filters = structuredClone(this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter)) as PublicRoutesFilter;
         if (filters.categories.includes(value)) {
             filters.categories = filters.categories.filter((x) => x !== value);
@@ -50,7 +50,7 @@ export class PublicRoutesFilterComponent {
         this.store.dispatch(new SetPublicRoutesFilterAction(filters));
     }
 
-    public onFilterDifficultyChange(value: string) {
+    public onFilterDifficultyChange(value: Difficulty) {
         const filters = structuredClone(this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter)) as PublicRoutesFilter;
         if (filters.difficulty.includes(value)) {
             filters.difficulty = filters.difficulty.filter((x) => x !== value);
@@ -60,7 +60,7 @@ export class PublicRoutesFilterComponent {
         this.store.dispatch(new SetPublicRoutesFilterAction(filters));
     }
 
-    public isCategorySelected(category: string) {
+    public isCategorySelected(category: CategoryType) {
         const filters = structuredClone(this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter)) as PublicRoutesFilter;
         return filters.categories.includes(category);
     }
@@ -75,7 +75,7 @@ export class PublicRoutesFilterComponent {
         return filters.difficulty.length !== initialState.inMemoryState.publicRoutesFilter.difficulty.length;
     }
 
-    public isDificultySelected(difficulty: string) {
+    public isDificultySelected(difficulty: Difficulty) {
         const filters = structuredClone(this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter)) as PublicRoutesFilter;
         return filters.difficulty.includes(difficulty);
     }

--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.html
@@ -135,6 +135,15 @@
                     {{resources.share}}
                 </button>
             </div>
+            @if (isEditable(selectedRoutePoint)) {
+            <div class="flex flex-row">
+                <button class="mt-2" (click)="navigateToEditPoi(selectedRoutePoint)" analyticsOn="click"
+                    analyticsCategory="Public routes" analyticsLabel="Edit OSM route">
+                    <i class="fa icon-pencil"></i>
+                    {{resources.editProperties}}
+                </button>
+            </div>
+            }
             <mat-menu #shareMenu="matMenu">
                 <a mat-menu-item [href]="getShareLinks(selectedRoutePoint).waze" [target]="'_blank'" analyticsOn="click"
                     analyticsCategory="Public routes" analyticsLabel="Navigate with waze">
@@ -171,8 +180,12 @@
                 }
             </mat-menu>
             <div class="flex flex-row mx-2">
-                <div class="relative w-full h-[200px]">
+                <div class="relative w-full h-[200px] overflow-hidden">
+                    @if (selectedRoutePoint.properties.image) {
                     <img class="w-full object-contain img-center" [src]="selectedRoutePoint.properties.image" alt="">
+                    } @else {
+                    <ng-lottie class="max-w-full img-center" [options]="lottieScenery"></ng-lottie>
+                    }
                 </div>
             </div>
             <div class="flex flex-row" class="text-center text-sm">
@@ -217,6 +230,13 @@
                         <i class="fa icon-plus"></i>
                         {{resources.addToRoutes}}
                     </button>
+                    @if (isEditable(route)) {
+                    <button mat-menu-item (click)="navigateToEditPoi(route)" analyticsOn="click"
+                        analyticsCategory="Public routes" analyticsLabel="Edit OSM route from list">
+                        <i class="fa icon-pencil"></i>
+                        {{resources.editProperties}}
+                    </button>
+                    }
                 </mat-menu>
                 @switch (route.properties.poiDifficulty) {
                 @case ("Easy") {
@@ -252,8 +272,12 @@
                 <span class="mx-2">{{resources.length}}: {{route.properties.poiLength | distance}}</span>
             </div>
             <div class="flex flex-row mx-10 max-md:mx-2">
-                <div class="relative w-full h-[200px]">
+                <div class="relative w-full h-[200px] overflow-hidden">
+                    @if (route.properties.image) {
                     <img class="w-full object-contain img-center" [src]="route.properties.image" alt="">
+                    } @else {
+                    <ng-lottie class="max-w-full img-center" [options]="lottieScenery"></ng-lottie>
+                    }
                 </div>
             </div>
             @defer (on viewport) {

--- a/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/public-routes.component.ts
@@ -13,6 +13,7 @@ import { MatMenu, MatMenuItem, MatMenuTrigger } from "@angular/material/menu";
 import { CdkCopyToClipboard } from "@angular/cdk/clipboard";
 import { Share } from "@capacitor/share";
 import { orderBy } from "lodash-es";
+import { AnimationOptions, LottieComponent } from "ngx-lottie";
 import type { StyleSpecification, Map, MapSourceDataEvent } from "maplibre-gl";
 
 import { ImageAttributionComponent } from "../image-attribution.component";
@@ -36,21 +37,24 @@ import { PoiProperties } from "../../services/osm-tags.service";
 import { RouteStrings } from "../../services/hash.service";
 import { Urls } from "../../urls";
 import type { ApplicationState } from "../../models";
+import sceneryPlaceholder from "../../../content/lottie/placeholder-scenery.json";
 
 @Component({
     selector: "public-routes",
     templateUrl: "./public-routes.component.html",
     styleUrls: ["./public-routes.component.scss"],
-    imports: [Dir, MapComponent, LayersComponent, VectorSourceComponent, LayerComponent, PopupComponent, MarkerComponent, MatButton, FormsModule, MatButtonToggleGroup, MatButtonToggle, AnalyticsDirective, NgClass, MatMenuTrigger, MatMenuItem, MatMenu, DistancePipe, GeoJSONSourceComponent, LayerComponent, CdkCopyToClipboard, ImageAttributionComponent, ZoomComponent, OsmAttributionComponent, ControlComponent, PublicRoutesFilterComponent, DescriptionComponent]
+    imports: [Dir, MapComponent, LayersComponent, VectorSourceComponent, LayerComponent, PopupComponent, MarkerComponent, MatButton, FormsModule, MatButtonToggleGroup, MatButtonToggle, AnalyticsDirective, NgClass, MatMenuTrigger, MatMenuItem, MatMenu, DistancePipe, GeoJSONSourceComponent, LayerComponent, CdkCopyToClipboard, ImageAttributionComponent, ZoomComponent, OsmAttributionComponent, ControlComponent, PublicRoutesFilterComponent, DescriptionComponent, LottieComponent]
 })
 export class PublicRoutesComponent {
+    public readonly lottieScenery: AnimationOptions = {
+        animationData: sceneryPlaceholder,
+    };
     public mapStyle: StyleSpecification;
     public showMap = true;
     public readonly routesSrouceId = "routes-of-interest";
 
-
     public poisVectorTileAddress = [Urls.baseTilesAddress.replace("https://", "slice://") + "/vector/data/global_points/{z}/{x}/{y}.mvt"];
-    public poiGeoJsonData: GeoJSON.FeatureCollection<GeoJSON.Point> = {
+    public poiGeoJsonData: GeoJSON.FeatureCollection<GeoJSON.Point, PoiProperties> = {
         type: "FeatureCollection",
         features: []
     };
@@ -59,7 +63,7 @@ export class PublicRoutesComponent {
         type: "FeatureCollection",
         features: []
     };
-    public selectedRoutePoint: GeoJSON.Feature<GeoJSON.Point> = null;
+    public selectedRoutePoint: GeoJSON.Feature<GeoJSON.Point, PoiProperties> = null;
 
     public readonly resources = inject(ResourcesService);
 
@@ -104,33 +108,9 @@ export class PublicRoutesComponent {
     }
 
     public runFilter() {
-        let features = this.poiService.getPublicRoutes(["Hiking", "Bicycle", "4x4"]).features;
         const filters = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.publicRoutesFilter);
-        features = features.filter(f => f.properties.image != null);
-        features = features.filter(feature => {
-            const units = this.store.selectSnapshot((s: ApplicationState) => s.configuration).units;
-            const factor = units === "metric" ? 1000.0 : 1609.344;
-            if (!filters.categories.includes(feature.properties.poiCategory)) {
-                return false;
-            }
-            if (feature.properties.poiDifficulty && !filters.difficulty.includes(feature.properties.poiDifficulty)) {
-                return false;
-            }
-            if (feature.properties.poiLength / factor < filters.lengthRange[0]) {
-                return false;
-            }
-            if (feature.properties.poiLength / factor > filters.lengthRange[1] && filters.lengthRange[1] < 50) {
-                return false;
-            }
-            if (filters.userId && feature.properties.poiUserId !== filters.userId) {
-                return false;
-            }
-            return true;
-        });
+        let features = this.poiService.getPublicRoutes(filters).features;
         const sortBy = [(f: GeoJSON.Feature<GeoJSON.Point, PoiProperties>) => f.properties.poiLength];
-
-
-
         features = orderBy(features, sortBy, ["desc"]);
         this.poiGeoJsonData = {
             type: "FeatureCollection",
@@ -138,7 +118,7 @@ export class PublicRoutesComponent {
         }
     }
 
-    public async onStartPointClick(feature: GeoJSON.Feature<GeoJSON.Point>, event: MouseEvent) {
+    public async onStartPointClick(feature: GeoJSON.Feature<GeoJSON.Point, PoiProperties>, event: MouseEvent) {
         event.stopPropagation();
         if (this.selectedRoutePoint?.properties.poiId === feature.properties.poiId) {
             this.selectedRoutePoint = null;
@@ -153,7 +133,7 @@ export class PublicRoutesComponent {
         this.moveToFeature(feature);
     }
 
-    public async moveToFeature(feature: GeoJSON.Feature<GeoJSON.Point>) {
+    public async moveToFeature(feature: GeoJSON.Feature<GeoJSON.Point, PoiProperties>) {
         this.showMap = true;
         this.selectedRoutePoint = feature;
         this.hoverFeature = null;
@@ -186,7 +166,7 @@ export class PublicRoutesComponent {
     }
 
 
-    public getIconFromType(feature: GeoJSON.Feature<GeoJSON.Point>) {
+    public getIconFromType(feature: GeoJSON.Feature<GeoJSON.Point, PoiProperties>) {
         switch (feature.properties.poiCategory) {
             case "Hiking":
                 return "icon-hike";
@@ -225,5 +205,14 @@ export class PublicRoutesComponent {
         Share.share({
             url: poiLink
         });
+    }
+
+    public isEditable(route: GeoJSON.Feature<GeoJSON.Point, PoiProperties>) {
+        return route.properties.poiSource === "OSM";
+    }
+
+    public navigateToEditPoi(route: GeoJSON.Feature<GeoJSON.Point, PoiProperties>) {
+        this.router.navigate([RouteStrings.ROUTE_POI, route.properties.poiSource, route.properties.identifier],
+            { queryParams: { edit: true } });
     }
 }

--- a/IsraelHiking.Web/src/application/components/search.component.ts
+++ b/IsraelHiking.Web/src/application/components/search.component.ts
@@ -120,8 +120,7 @@ export class SearchComponent {
             return;
         }
 
-        this.router.navigate([RouteStrings.ROUTE_POI, searchResults.source, searchResults.id],
-            { queryParams: { language: this.resources.getCurrentLanguageCodeSimplified() } });
+        this.router.navigate([RouteStrings.ROUTE_POI, searchResults.source, searchResults.id]);
     }
 
     private selectResults(searchContext: SearchContext, searchResult: SearchResultsPointOfInterest) {

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/image-scroller.component.html
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/image-scroller.component.html
@@ -15,7 +15,7 @@
 </div>
 } @else {
 <div class="flex flex-row">
-  <div class="relative w-full h-[200px] overflow-hidden" dnd-droppable (onDropSuccess)="add($event.mouseEvent)">
+  <div class="relative w-full h-[200px]" dnd-droppable (onDropSuccess)="add($event.mouseEvent)">
     <img [src]="getCurrentImage()" class="w-full object-contain cursor-zoom-in img-center" (click)="showImage()" />
   </div>
 </div>

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/image-scroller.component.html
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/image-scroller.component.html
@@ -8,14 +8,14 @@
     <input type="file" (change)="add($event)" [style.display]="'none'" accept="image/*;capture=camera" multiple />
   </label>
   } @else {
-  <div class="relative w-full h-[200px]" style="overflow: hidden;">
+  <div class="relative w-full h-[200px] overflow-hidden">
     <ng-lottie class="max-w-full img-center" [options]="lottiePOI"></ng-lottie>
   </div>
   }
 </div>
 } @else {
 <div class="flex flex-row">
-  <div class="relative w-full h-[200px]" dnd-droppable (onDropSuccess)="add($event.mouseEvent)">
+  <div class="relative w-full h-[200px] overflow-hidden" dnd-droppable (onDropSuccess)="add($event.mouseEvent)">
     <img [src]="getCurrentImage()" class="w-full object-contain cursor-zoom-in img-center" (click)="showImage()" />
   </div>
 </div>

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/image-scroller.component.ts
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/image-scroller.component.ts
@@ -18,7 +18,7 @@ import sceneryPlaceholder from "../../../../content/lottie/placeholder-scenery.j
     imports: [LottieComponent, MatAnchor, ImageCaptureDirective, AnalyticsDirective, MatButton, Dir, ImageAttributionComponent]
 })
 export class ImageScrollerComponent implements OnChanges {
-    lottiePOI: AnimationOptions = {
+    public readonly lottiePOI: AnimationOptions = {
         animationData: sceneryPlaceholder,
     };
 

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.ts
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.ts
@@ -93,13 +93,11 @@ export class PublicPoiSidebarComponent implements OnDestroy {
         });
         this.store.select((state: ApplicationState) => state.configuration.language).pipe(takeUntilDestroyed(), skip(1)).subscribe(() => {
             const sourceIdAndLanguage = this.getRouteUrlInfo();
-            const queryParams: Record<string, string | boolean> = {
-                language: this.resources.getCurrentLanguageCodeSimplified()
-            };
+            const queryParams: Record<string, boolean> = {};
             if (sourceIdAndLanguage.editMode) {
                 queryParams.edit = true;
             }
-            this.router.navigate([RouteStrings.ROUTE_POI, sourceIdAndLanguage.source, sourceIdAndLanguage.id]);
+            this.router.navigate([RouteStrings.ROUTE_POI, sourceIdAndLanguage.source, sourceIdAndLanguage.id], { queryParams });
         });
         this.initOrUpdate();
     }

--- a/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.ts
+++ b/IsraelHiking.Web/src/application/components/sidebar/publicpoi/public-poi-sidebar.component.ts
@@ -99,7 +99,7 @@ export class PublicPoiSidebarComponent implements OnDestroy {
             if (sourceIdAndLanguage.editMode) {
                 queryParams.edit = true;
             }
-            this.router.navigate([RouteStrings.ROUTE_POI, sourceIdAndLanguage.source, sourceIdAndLanguage.id], { queryParams });
+            this.router.navigate([RouteStrings.ROUTE_POI, sourceIdAndLanguage.source, sourceIdAndLanguage.id]);
         });
         this.initOrUpdate();
     }
@@ -225,7 +225,7 @@ export class PublicPoiSidebarComponent implements OnDestroy {
             return;
         }
         this.router.navigate([RouteStrings.ROUTE_POI, this.fullFeature.properties.poiSource, this.fullFeature.properties.identifier],
-            { queryParams: { language: this.resources.getCurrentLanguageCodeSimplified(), edit: true } });
+            { queryParams: { edit: true } });
     }
 
     public isEditable() {

--- a/IsraelHiking.Web/src/application/models/index.d.ts
+++ b/IsraelHiking.Web/src/application/models/index.d.ts
@@ -13,6 +13,7 @@ export type RoutingType = components["schemas"]["RouteSegmentData"]["routingType
 export type DataContainer = components["schemas"]["DataContainer"];
 export type UserPermissions = components["schemas"]["UserPermissions"];
 export type ActivityType = ShareUrl["type"];
+export type Difficulty = ShareUrl["difficulty"];
 
 export type RouteEditStateType = "Poi" | "Route" | "ReadOnly" | "Hidden";
 export type { Bounds } from "./bounds";
@@ -25,7 +26,7 @@ export type { NorthEast } from "./north-east";
 export type { Category, IconColorLabel } from "./category";
 export type { Language, LanguageCode } from "./language";
 export type { RecordedRoute } from "./recorded-route";
-export type { PublicRoutesFilter } from "./public-routes-filter";
+export type { CategoryType, PublicRoutesFilter } from "./public-routes-filter";
 // states:
 export type { ApplicationState, MutableApplicationState } from "./state/application-state";
 export type { ConfigurationState, BatteryOptimizationType } from "./state/configuration-state";

--- a/IsraelHiking.Web/src/application/models/public-routes-filter.d.ts
+++ b/IsraelHiking.Web/src/application/models/public-routes-filter.d.ts
@@ -1,6 +1,10 @@
+import { Difficulty } from "./";
+
+export type CategoryType = "Hiking" | "Bicycle" | "4x4";
+
 export type PublicRoutesFilter = {
-    categories: string[];
-    difficulty: string[];
+    categories: CategoryType[];
+    difficulty: Difficulty[];
     lengthRange: [number, number];
     userId: string;
 }

--- a/IsraelHiking.Web/src/application/services/open-with.service.ts
+++ b/IsraelHiking.Web/src/application/services/open-with.service.ts
@@ -63,10 +63,8 @@ export class OpenWithService {
             const sourceAndId = pathname.replace(RouteStrings.ROUTE_POI + "/", "");
             const source = sourceAndId.split("/")[0];
             const id = sourceAndId.split("/")[1];
-            const language = new URLSearchParams(url.search).get("language");
             this.ngZone.run(() => {
-                this.router.navigate([RouteStrings.ROUTE_POI, source, id],
-                    { queryParams: { language } });
+                this.router.navigate([RouteStrings.ROUTE_POI, source, id]);
             });
         } else if (pathname.startsWith(RouteStrings.ROUTE_URL)) {
             const urlData = pathname.replace(RouteStrings.ROUTE_URL + "/", "");
@@ -140,8 +138,7 @@ export class OpenWithService {
     private moveToCoordinates(coords: string[]) {
         const latLng = SpatialService.toLatLng([+coords[2], +coords[1]]);
         this.ngZone.run(() => {
-            this.router.navigate([RouteStrings.ROUTE_POI, RouteStrings.COORDINATES, getIdFromLatLng(latLng)],
-                { queryParams: { language: this.resources.getCurrentLanguageCodeSimplified() } });
+            this.router.navigate([RouteStrings.ROUTE_POI, RouteStrings.COORDINATES, getIdFromLatLng(latLng)]);
         });
     }
 }

--- a/IsraelHiking.Web/src/application/services/osm-tags.service.ts
+++ b/IsraelHiking.Web/src/application/services/osm-tags.service.ts
@@ -1,4 +1,4 @@
-import type { LatLngAltTime } from "../models";
+import type { CategoryType, Difficulty, LatLngAltTime } from "../models";
 
 export type PoiProperties = {
     poiSource: string;
@@ -7,9 +7,9 @@ export type PoiProperties = {
     poiGeolocation: LatLngAltTime;
     poiIconColor: string;
     poiIcon: string;
-    poiCategory: string;
+    poiCategory: CategoryType | string;
     poiLength: number;
-    poiDifficulty: string;
+    poiDifficulty: Difficulty;
     poiUserId?: string;
     "name:he"?: string;
     "name:en"?: string;

--- a/IsraelHiking.Web/src/application/services/poi.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.spec.ts
@@ -30,7 +30,6 @@ import type { ApplicationState, LatLngAltTime } from "../models";
 import { NakebService } from "./nakeb.service";
 
 describe("Poi Service", () => {
-
     beforeEach(() => {
         const hashService = {
             getFullUrlFromPoiId: (s: PoiRouteUrlInfo) => s.source + "/" + s.id,
@@ -219,9 +218,187 @@ describe("Poi Service", () => {
         }
     )));
 
-    it("Should not get public routes for empty categories", (inject([PoiService],
-        async (poiService: PoiService) => {
-            expect(poiService.getPublicRoutes([]).features.length).toBe(0);
+    it("Should not get public routes for empty categories", (inject([PoiService, Store, MapService],
+        async (poiService: PoiService, store: Store, mapServiceMock: MapService) => {
+            store.reset({
+                configuration: {
+                    language: "he"
+                }
+            });
+            mapServiceMock.getFeaturesFromTiles = () => [
+                {
+                    id: "11",
+                    geometry: {
+                        type: "LineString",
+                        coordinates: [[0, 0], [1, 1]]
+                    },
+                    properties: {
+                        poiId: "42",
+                        poiCategory: "Hiking",
+                        poiIconColor: "black",
+                        poiIcon: "icon-hike",
+                        poiLength: 10000,
+                        poiDifficulty: "Hard",
+                        name: "line",
+                        "name:he": "line"
+                    }
+                }
+            ] as any;
+
+            expect(poiService.getPublicRoutes({ categories: [], lengthRange: [0, 50], difficulty: ["Hard", "Easy"], userId: "" }).features.length).toBe(0);
+        }
+    )));
+
+    it("Should not get public routes with unselected category", (inject([PoiService, Store, MapService],
+        async (poiService: PoiService, store: Store, mapServiceMock: MapService) => {
+            store.reset({
+                configuration: {
+                    language: "he"
+                }
+            });
+            mapServiceMock.getFeaturesFromTiles = () => [
+                {
+                    id: "11",
+                    geometry: {
+                        type: "LineString",
+                        coordinates: [[0, 0], [1, 1]]
+                    },
+                    properties: {
+                        poiId: "42",
+                        poiCategory: "Hiking",
+                        poiIconColor: "black",
+                        poiIcon: "icon-hike",
+                        poiLength: 10000,
+                        poiDifficulty: "Hard",
+                        name: "line",
+                        "name:he": "line"
+                    }
+                }
+            ] as any;
+            expect(poiService.getPublicRoutes({ categories: ["Biking"], lengthRange: [0, 50], difficulty: ["Hard", "Easy"], userId: "" }).features.length).toBe(0);
+        }
+    )));
+
+    it("Should not get public routes with unselected difficulty", (inject([PoiService, Store, MapService],
+        async (poiService: PoiService, store: Store, mapServiceMock: MapService) => {
+            store.reset({
+                configuration: {
+                    language: "he"
+                }
+            });
+            mapServiceMock.getFeaturesFromTiles = () => [
+                {
+                    id: "11",
+                    geometry: {
+                        type: "LineString",
+                        coordinates: [[0, 0], [1, 1]]
+                    },
+                    properties: {
+                        poiId: "42",
+                        poiCategory: "Hiking",
+                        poiIconColor: "black",
+                        poiIcon: "icon-hike",
+                        poiLength: 10000,
+                        poiDifficulty: "Hard",
+                        name: "line",
+                        "name:he": "line"
+                    }
+                }
+            ] as any;
+            expect(poiService.getPublicRoutes({ categories: ["Hiking"], lengthRange: [0, 50], difficulty: ["Easy"], userId: "" }).features.length).toBe(0);
+        }
+    )));
+
+    it("Should not get public routes with too short length", (inject([PoiService, Store, MapService],
+        async (poiService: PoiService, store: Store, mapServiceMock: MapService) => {
+            store.reset({
+                configuration: {
+                    language: "he",
+                    unit: "metric"
+                }
+            });
+            mapServiceMock.getFeaturesFromTiles = () => [
+                {
+                    id: "11",
+                    geometry: {
+                        type: "LineString",
+                        coordinates: [[0, 0], [1, 1]]
+                    },
+                    properties: {
+                        poiId: "42",
+                        poiCategory: "Hiking",
+                        poiIconColor: "black",
+                        poiIcon: "icon-hike",
+                        poiLength: 10000,
+                        poiDifficulty: "Hard",
+                        name: "line",
+                        "name:he": "line"
+                    }
+                }
+            ] as any;
+            expect(poiService.getPublicRoutes({ categories: ["Hiking"], lengthRange: [15, 50], difficulty: ["Hard"], userId: "" }).features.length).toBe(0);
+        }
+    )));
+
+    it("Should not get public routes with too long length", (inject([PoiService, Store, MapService],
+        async (poiService: PoiService, store: Store, mapServiceMock: MapService) => {
+            store.reset({
+                configuration: {
+                    language: "he",
+                    unit: "metric"
+                }
+            });
+            mapServiceMock.getFeaturesFromTiles = () => [
+                {
+                    id: "11",
+                    geometry: {
+                        type: "LineString",
+                        coordinates: [[0, 0], [1, 1]]
+                    },
+                    properties: {
+                        poiId: "42",
+                        poiCategory: "Hiking",
+                        poiIconColor: "black",
+                        poiIcon: "icon-hike",
+                        poiLength: 10000,
+                        poiDifficulty: "Hard",
+                        name: "line",
+                        "name:he": "line"
+                    }
+                }
+            ] as any;
+            expect(poiService.getPublicRoutes({ categories: ["Hiking"], lengthRange: [0, 5], difficulty: ["Hard"], userId: "" }).features.length).toBe(0);
+        }
+    )));
+
+    it("Should not get public routes for incorrect user id", (inject([PoiService, Store, MapService],
+        async (poiService: PoiService, store: Store, mapServiceMock: MapService) => {
+            store.reset({
+                configuration: {
+                    language: "he"
+                }
+            });
+            mapServiceMock.getFeaturesFromTiles = () => [
+                {
+                    id: "11",
+                    geometry: {
+                        type: "LineString",
+                        coordinates: [[0, 0], [1, 1]]
+                    },
+                    properties: {
+                        poiId: "42",
+                        poiCategory: "Hiking",
+                        poiIconColor: "black",
+                        poiIcon: "icon-hike",
+                        poiLength: 10000,
+                        poiDifficulty: "Hard",
+                        osmUserId: "123",
+                        name: "line",
+                        "name:he": "line"
+                    }
+                }
+            ] as any;
+            expect(poiService.getPublicRoutes({ categories: ["Hiking"], lengthRange: [0, 50], difficulty: ["Hard", "Easy"], userId: "42" }).features.length).toBe(0);
         }
     )));
 
@@ -244,40 +421,14 @@ describe("Poi Service", () => {
                         poiCategory: "Hiking",
                         poiIconColor: "black",
                         poiIcon: "icon-hike",
+                        poiLength: 10000,
+                        poiDifficulty: "Hard",
                         name: "line",
                         "name:he": "line"
                     }
                 }
             ] as any;
-            expect(poiService.getPublicRoutes(["Hiking"]).features.length).toBe(1);
-        }
-    )));
-
-    it("Should not get public routes for tiles for incorrect category", (inject([PoiService, Store, MapService],
-        async (poiService: PoiService, store: Store, mapServiceMock: MapService) => {
-            store.reset({
-                configuration: {
-                    language: "he"
-                }
-            });
-            mapServiceMock.getFeaturesFromTiles = () => [
-                {
-                    id: "11",
-                    geometry: {
-                        type: "LineString",
-                        coordinates: [[0, 0], [1, 1]]
-                    },
-                    properties: {
-                        poiId: "42",
-                        poiCategory: "Hiking",
-                        poiIconColor: "black",
-                        poiIcon: "icon-hike",
-                        name: "line",
-                        "name:he": "line"
-                    }
-                }
-            ] as any;
-            expect(poiService.getPublicRoutes(["Biking"]).features.length).toBe(0);
+            expect(poiService.getPublicRoutes({ categories: ["Hiking"], lengthRange: [0, 50], difficulty: ["Hard", "Easy"], userId: "" }).features.length).toBe(1);
         }
     )));
 

--- a/IsraelHiking.Web/src/application/services/poi.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.spec.ts
@@ -275,7 +275,7 @@ describe("Poi Service", () => {
                     }
                 }
             ] as any;
-            expect(poiService.getPublicRoutes({ categories: ["Biking"], lengthRange: [0, 50], difficulty: ["Hard", "Easy"], userId: "" }).features.length).toBe(0);
+            expect(poiService.getPublicRoutes({ categories: ["Bicycle"], lengthRange: [0, 50], difficulty: ["Hard", "Easy"], userId: "" }).features.length).toBe(0);
         }
     )));
 

--- a/IsraelHiking.Web/src/application/services/poi.service.ts
+++ b/IsraelHiking.Web/src/application/services/poi.service.ts
@@ -35,7 +35,8 @@ import type {
     NorthEast,
     EditablePublicPointData,
     UpdateablePublicPoiData,
-    ShareUrl
+    ShareUrl,
+    PublicRoutesFilter
 } from "../models";
 
 export type SimplePointType = "Tap" | "CattleGrid" | "Parking" | "OpenGate" | "ClosedGate" | "Block" | "PicnicSite" | "Bench"
@@ -272,17 +273,36 @@ export class PoiService {
         };
     }
 
-    public getPublicRoutes(categoires: string[]): GeoJSON.FeatureCollection<GeoJSON.Point, PoiProperties> {
-        if (categoires.length === 0) {
+    public getPublicRoutes(filters: Immutable<PublicRoutesFilter>): GeoJSON.FeatureCollection<GeoJSON.Point, PoiProperties> {
+        if (filters.categories.length === 0) {
             return {
                 type: "FeatureCollection",
                 features: []
             };
         }
-        const tileFeautes = this.getPoisFromTiles();
+        const units = this.store.selectSnapshot((s: ApplicationState) => s.configuration).units;
+        const factor = units === "metric" ? 1000.0 : 1609.344;
+        let features = this.getPoisFromTiles();
+        features = this.filterFeatures(features, filters.categories);
+        features = features.filter(feature => {
+            if (feature.properties.poiDifficulty && !filters.difficulty.includes(feature.properties.poiDifficulty)) {
+                return false;
+            }
+            if (feature.properties.poiLength / factor < filters.lengthRange[0]) {
+                return false;
+            }
+            if (feature.properties.poiLength / factor > filters.lengthRange[1] && filters.lengthRange[1] < 50) {
+                return false;
+            }
+            if (filters.userId && feature.properties.poiUserId !== filters.userId) {
+                return false;
+            }
+            return true;
+        });
+
         return {
             type: "FeatureCollection",
-            features: this.filterFeatures(tileFeautes, categoires)
+            features
         };
     }
 

--- a/IsraelHiking.Web/src/application/services/share-urls.service.ts
+++ b/IsraelHiking.Web/src/application/services/share-urls.service.ts
@@ -15,7 +15,7 @@ import { SetShareUrlAction } from "../reducers/in-memory.reducer";
 import { UpdateShareUrlAction, RemoveShareUrlAction, AddShareUrlAction, SetShareUrlsLastModifiedDateAction } from "../reducers/share-urls.reducer";
 import { SpatialService } from "./spatial.service";
 import { Urls } from "../urls";
-import type { ShareUrl, ApplicationState, UserPermissions } from "../models";
+import type { ShareUrl, ApplicationState, UserPermissions, ActivityType } from "../models";
 
 interface IShareUrlSocialLinks {
     facebook: string;
@@ -222,7 +222,7 @@ export class ShareUrlsService {
         return await firstValueFrom(this.httpClient.get<UserPermissions>(Urls.permissions));
     }
 
-    public getIconFromType(type: ShareUrl["type"]) {
+    public getIconFromType(type: ActivityType) {
         switch (type) {
             case "Hiking":
                 return "icon-hike";


### PR DESCRIPTION
This includes routes without images in the public routes screen.

- Resolves #2507 
 
It also removes the extra "language" query parameter from the POI.
It adds the ability to go and edit a route that belongs to OSM, this functionality what removed to some extent when removing the routes from the plan & explore screen, so I added it back.
