### PR TITLE
Support dynamic contours in native (car)

### DIFF
--- a/IsraelHiking.Web/android/app/build.gradle
+++ b/IsraelHiking.Web/android/app/build.gradle
@@ -49,7 +49,8 @@ dependencies {
     implementation "org.maplibre.gl:android-sdk:$maplibreSdkVersion"
     implementation "org.maplibre.gl:android-sdk-turf:$maplibreTurfVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "com.github.mapeak-com:pmtiles-mobile:v0.3.1"
+    implementation "com.github.mapeak-com:pmtiles-mobile:v0.3.2"
+    implementation "com.github.mapeak-com:maplibre-contour-rs:v0.4.1"
     implementation "androidx.core:core-ktx:$androidxCoreKtxVersion"
     implementation "com.google.android.gms:play-services-location:$playServicesLocationVersion"
 }

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarContourTilesProvider.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarContourTilesProvider.kt
@@ -10,19 +10,18 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 
 /**
- * Generates vector contour tiles on the fly from a terrain (DEM) source, mirroring what
- * maplibre-contour does on the web. The heavy lifting is done by the maplibre-contour-rs native
- * library: we hand it a [DemTileFetcher] that knows how to download a DEM tile, and it returns a
- * ready-to-render MVT for any `z/x/y`. [SliceProtocolInterceptor] is what routes contour tile
- * requests here, passing the units carried in the tile URL.
+ * Generates vector contour tiles on the fly from a terrain (DEM) source. The heavy lifting is done
+ * by the maplibre-contour-rs native library: we hand it a [DemTileFetcher] that knows how to
+ * download a DEM tile, and it returns a ready-to-render MVT for any `z/x/y`.
+ * [SliceProtocolInterceptor] is what routes contour tile requests here, passing the units carried
+ * in the tile URL.
  *
- * Units (metric/imperial) only change the elevation multiplier, so a manager is built and cached per
- * units string; the managers are thread-safe and shared across requests.
+ * Units (metric/imperial) only change the elevation multiplier, so a manager is built and cached
+ * per units string; the managers are thread-safe and shared across requests.
  */
 class CarContourTilesProvider internal constructor(private val okHttpClient: OkHttpClient) {
 
-    // The layer/attribute names and thresholds must match what the style's contour layers expect
-    // (see the web useContourProtocol in default-style.service.ts, which configures the same values).
+    private val managers = ConcurrentHashMap<String, DemManager>()
     private val config =
             defaultConfig()
                     .copy(
@@ -40,10 +39,6 @@ class CarContourTilesProvider internal constructor(private val okHttpClient: OkH
                             levelKey = "level",
                     )
 
-    // Called by the native library to download the raw DEM tile bytes for a fully-resolved URL.
-    // okHttpClient carries SliceProtocolInterceptor (the `use=slice` marker in demUrlPattern), so
-    // DEM fetches get the same offline (PMTiles) fallback the rest of the map enjoys. Returning null
-    // tells the library there is no data for that tile, which it renders as an empty contour tile.
     private val fetcher =
             object : DemTileFetcher {
                 override fun fetch(url: String): ByteArray? {
@@ -56,9 +51,6 @@ class CarContourTilesProvider internal constructor(private val okHttpClient: OkH
                     }
                 }
             }
-
-    // One manager per units string; metric and imperial differ only by the elevation multiplier.
-    private val managers = ConcurrentHashMap<String, DemManager>()
 
     fun getTile(z: Int, x: Int, y: Int, units: String): ByteArray {
         val manager =

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarContourTilesProvider.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarContourTilesProvider.kt
@@ -39,6 +39,8 @@ class CarContourTilesProvider internal constructor(private val okHttpClient: OkH
                             levelKey = "level",
                     )
 
+    // This needs to be provided in order to force the Rust code to use the okhttp, so that
+    // "use=slice" will route back to pmtiles/online mode
     private val fetcher =
             object : DemTileFetcher {
                 override fun fetch(url: String): ByteArray? {

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarContourTilesProvider.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarContourTilesProvider.kt
@@ -1,0 +1,79 @@
+package com.mapeak.car
+
+import com.mapeak.maplibrecontour.DemManager
+import com.mapeak.maplibrecontour.DemTileFetcher
+import com.mapeak.maplibrecontour.Encoding
+import com.mapeak.maplibrecontour.defaultConfig
+import com.mapeak.maplibrecontour.parseThresholdSpec
+import java.util.concurrent.ConcurrentHashMap
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Generates vector contour tiles on the fly from a terrain (DEM) source, mirroring what
+ * maplibre-contour does on the web. The heavy lifting is done by the maplibre-contour-rs native
+ * library: we hand it a [DemTileFetcher] that knows how to download a DEM tile, and it returns a
+ * ready-to-render MVT for any `z/x/y`. [SliceProtocolInterceptor] is what routes contour tile
+ * requests here, passing the units carried in the tile URL.
+ *
+ * Units (metric/imperial) only change the elevation multiplier, so a manager is built and cached per
+ * units string; the managers are thread-safe and shared across requests.
+ */
+class CarContourTilesProvider internal constructor(private val okHttpClient: OkHttpClient) {
+
+    // The layer/attribute names and thresholds must match what the style's contour layers expect
+    // (see the web useContourProtocol in default-style.service.ts, which configures the same values).
+    private val config =
+            defaultConfig()
+                    .copy(
+                            encoding = Encoding.TERRARIUM,
+                            demUrlPattern =
+                                    "https://global.israelhikingmap.workers.dev/jaxa_terrarium0-11_v2/{z}/{x}/{y}.webp?use=slice",
+                            demMaxZoom = 11.toUByte(),
+                            overzoom = 1.toUByte(),
+                            thresholds =
+                                    parseThresholdSpec(
+                                            "11*200*1000~12*10*100~13*10*100~14*10*100~15*10*100"
+                                    ),
+                            layerName = "contours",
+                            elevationKey = "ele",
+                            levelKey = "level",
+                    )
+
+    // Called by the native library to download the raw DEM tile bytes for a fully-resolved URL.
+    // okHttpClient carries SliceProtocolInterceptor (the `use=slice` marker in demUrlPattern), so
+    // DEM fetches get the same offline (PMTiles) fallback the rest of the map enjoys. Returning null
+    // tells the library there is no data for that tile, which it renders as an empty contour tile.
+    private val fetcher =
+            object : DemTileFetcher {
+                override fun fetch(url: String): ByteArray? {
+                    val request = Request.Builder().url(url).build()
+                    okHttpClient.newCall(request).execute().use { response ->
+                        if (!response.isSuccessful) {
+                            return null
+                        }
+                        return response.body.bytes()
+                    }
+                }
+            }
+
+    // One manager per units string; metric and imperial differ only by the elevation multiplier.
+    private val managers = ConcurrentHashMap<String, DemManager>()
+
+    fun getTile(z: Int, x: Int, y: Int, units: String): ByteArray {
+        val manager =
+                managers.computeIfAbsent(units) {
+                    DemManager(fetcher, config.copy(multiplier = multiplierForUnits(it)))
+                }
+        return manager.tile(z.toUByte(), x.toUInt(), y.toUInt())
+    }
+
+    companion object {
+        private const val UNIT_IMPERIAL = "imperial"
+        private const val METRIC_MULTIPLIER = 1.0f
+        private const val IMPERIAL_MULTIPLIER = 3.28084f
+
+        private fun multiplierForUnits(units: String): Float =
+                if (units == UNIT_IMPERIAL) IMPERIAL_MULTIPLIER else METRIC_MULTIPLIER
+    }
+}

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarMapContainer.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarMapContainer.kt
@@ -76,7 +76,8 @@ class CarMapContainer(private val carContext: CarContext) : CapacitorStore.Liste
     /**
      * Centers the map on [location], pushing the GPS dot into the bottom third of the visible area
      * so what's ahead stays in view and the dot can't slip under another app docked on the Android
-     * Auto surface. Bearing rotates the map; the zoom follows the current speed (see [zoomForSpeed]).
+     * Auto surface. Bearing rotates the map; the zoom follows the current speed (see [zoomForSpeed]
+     * ).
      */
     private fun centerOnLocation(location: Location) {
         val bearing = if (location.hasBearing()) location.bearing.toDouble() else 0.0
@@ -178,8 +179,8 @@ class CarMapContainer(private val carContext: CarContext) : CapacitorStore.Liste
     /**
      * Eases the camera so that [lat]/[lng] appears at screen ([anchorX], [anchorY]) — the camera
      * target normally lands at the view's geometric center, so the target is shifted to compensate.
-     * Applies [bearing], and the optional [zoom] is folded into the same ease (leaving it null keeps
-     * the current zoom) so the speed zoom never fights the centering animation.
+     * Applies [bearing], and the optional [zoom] is folded into the same ease (leaving it null
+     * keeps the current zoom) so the speed zoom never fights the centering animation.
      */
     fun setCenter(
             lat: Double,
@@ -451,9 +452,6 @@ class CarMapContainer(private val carContext: CarContext) : CapacitorStore.Liste
     @MainThread
     fun setupMap(pixelRatio: Float): View {
         MapLibre.getInstance(carContext)
-        // One client serves MapLibre's tiles, the DEM fetches, and the PMTiles offline fallback. The
-        // contour provider fetches DEM tiles through this same client, so it is wired into the
-        // interceptor after the client is built.
         val sliceInterceptor = SliceProtocolInterceptor(PmTilesService(carContext))
         val tileHttpClient = OkHttpClient.Builder().addInterceptor(sliceInterceptor).build()
         sliceInterceptor.contoursProvider = CarContourTilesProvider(tileHttpClient)

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarMapContainer.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/CarMapContainer.kt
@@ -451,11 +451,13 @@ class CarMapContainer(private val carContext: CarContext) : CapacitorStore.Liste
     @MainThread
     fun setupMap(pixelRatio: Float): View {
         MapLibre.getInstance(carContext)
-        HttpRequestUtil.setOkHttpClient(
-                OkHttpClient.Builder()
-                        .addInterceptor(SliceProtocolInterceptor(PmTilesService(carContext)))
-                        .build()
-        )
+        // One client serves MapLibre's tiles, the DEM fetches, and the PMTiles offline fallback. The
+        // contour provider fetches DEM tiles through this same client, so it is wired into the
+        // interceptor after the client is built.
+        val sliceInterceptor = SliceProtocolInterceptor(PmTilesService(carContext))
+        val tileHttpClient = OkHttpClient.Builder().addInterceptor(sliceInterceptor).build()
+        sliceInterceptor.contoursProvider = CarContourTilesProvider(tileHttpClient)
+        HttpRequestUtil.setOkHttpClient(tileHttpClient)
         routes = CarRouteData.listFromJson(store.load(CarStoreKeys.ROUTE))
 
         val mapView = createMapViewInstance(pixelRatio).apply { onStart() }

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
@@ -10,6 +10,13 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 
 class SliceProtocolInterceptor internal constructor(private val pmTilesService: PmTilesService) :
         Interceptor {
+    /**
+     * Generates contour vector tiles on the fly. Set after construction: the provider fetches DEM
+     * tiles through the OkHttpClient that wraps this interceptor, so the client must be built first.
+     * When null, contour-source requests fall through to the normal slice/PMTiles handling.
+     */
+    var contoursProvider: CarContourTilesProvider? = null
+
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val original = chain.request()
@@ -29,6 +36,28 @@ class SliceProtocolInterceptor internal constructor(private val pmTilesService: 
                                 .dropLastWhile { it.isEmpty() }
                                 .toTypedArray()[0]
                         .toInt()
+
+        // The contour source carries a `contour=<units>` marker (see useContourQuery on the web);
+        // there are no offline PMTiles for it, so we generate the MVT locally from the DEM, mirroring
+        // maplibre-contour on the web. The units in the URL also key MapLibre's cache, so a unit
+        // change naturally re-requests fresh tiles.
+        val contourUnits = original.url.queryParameter("contour")
+        val contoursProvider = this.contoursProvider
+        if (contoursProvider != null && contourUnits != null) {
+            val data =
+                    try {
+                        contoursProvider.getTile(z, x, y, contourUnits)
+                    } catch (ex: Exception) {
+                        throw IOException("Failed to generate contour tile $z/$x/$y", ex)
+                    }
+            return Response.Builder()
+                    .request(original)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(data.toResponseBody("application/x-protobuf".toMediaType()))
+                    .build()
+        }
 
         val offlineAvailable = pmTilesService.isOfflineFileAvailable(z, x, y, type)
         val timeout: Int =

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
@@ -10,11 +10,6 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 
 class SliceProtocolInterceptor internal constructor(private val pmTilesService: PmTilesService) :
         Interceptor {
-    /**
-     * Generates contour vector tiles on the fly. Set after construction: the provider fetches DEM
-     * tiles through the OkHttpClient that wraps this interceptor, so the client must be built
-     * first. When null, contour-source requests fall through to the normal slice/PMTiles handling.
-     */
     var contoursProvider: CarContourTilesProvider? = null
 
     @Throws(IOException::class)

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
@@ -12,8 +12,8 @@ class SliceProtocolInterceptor internal constructor(private val pmTilesService: 
         Interceptor {
     /**
      * Generates contour vector tiles on the fly. Set after construction: the provider fetches DEM
-     * tiles through the OkHttpClient that wraps this interceptor, so the client must be built first.
-     * When null, contour-source requests fall through to the normal slice/PMTiles handling.
+     * tiles through the OkHttpClient that wraps this interceptor, so the client must be built
+     * first. When null, contour-source requests fall through to the normal slice/PMTiles handling.
      */
     var contoursProvider: CarContourTilesProvider? = null
 
@@ -37,10 +37,6 @@ class SliceProtocolInterceptor internal constructor(private val pmTilesService: 
                                 .toTypedArray()[0]
                         .toInt()
 
-        // The contour source carries a `contour=<units>` marker (see useContourQuery on the web);
-        // there are no offline PMTiles for it, so we generate the MVT locally from the DEM, mirroring
-        // maplibre-contour on the web. The units in the URL also key MapLibre's cache, so a unit
-        // change naturally re-requests fresh tiles.
         val contourUnits = original.url.queryParameter("contour")
         val contoursProvider = this.contoursProvider
         if (contoursProvider != null && contourUnits != null) {

--- a/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
+++ b/IsraelHiking.Web/android/app/src/main/java/com/mapeak/car/SliceProtocolInterceptor.kt
@@ -8,6 +8,7 @@ import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 
+/** Supports service "use=silce". It also routes the "contour=units" to the contour manager. */
 class SliceProtocolInterceptor internal constructor(private val pmTilesService: PmTilesService) :
         Interceptor {
     var contoursProvider: CarContourTilesProvider? = null

--- a/IsraelHiking.Web/android/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/IsraelHiking.Web/android/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,2 +1,2 @@
-- Add support for Android Auto
+- Add support for Android Auto with dynamic contours
 - Various bug fixes and performance improvements

--- a/IsraelHiking.Web/ios/App/App.xcodeproj/project.pbxproj
+++ b/IsraelHiking.Web/ios/App/App.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		0D4587ED2FCCC8A300269001 /* CarStoreKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4587EC2FCCC8A300269001 /* CarStoreKeys.swift */; };
-		0D4587F02FCE3AAD00269001 /* PMTiles in Frameworks */ = {isa = PBXBuildFile; productRef = 0D4587EF2FCE3AAD00269001 /* PMTiles */; };
-		0D46EA052FCC509C0033E098 /* PMTiles in Frameworks */ = {isa = PBXBuildFile; productRef = 0D46EA042FCC509C0033E098 /* PMTiles */; };
 		0D46EA142FCC67830033E098 /* CarStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D46EA0F2FCC67830033E098 /* CarStatistics.swift */; };
 		0D46EA152FCC67830033E098 /* SliceURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D46EA132FCC67830033E098 /* SliceURLProtocol.swift */; };
 		0D46EA162FCC67830033E098 /* CarMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D46EA0C2FCC67830033E098 /* CarMapViewController.swift */; };
@@ -20,7 +18,8 @@
 		0D46EA1B2FCC67830033E098 /* PMTilesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D46EA122FCC67830033E098 /* PMTilesService.swift */; };
 		0D46EA1C2FCC67830033E098 /* MapeakCarSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D46EA112FCC67830033E098 /* MapeakCarSceneDelegate.swift */; };
 		0D46EA1E2FCC68230033E098 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D46EA1D2FCC68230033E098 /* SceneDelegate.swift */; };
-		0DD5D9562FDBDAF700983BAA /* PMTiles in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD5D9552FDBDAF700983BAA /* PMTiles */; };
+		0D6243222FDEC4F900B2C10A /* CarContourTilesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D6243212FDEC4F000B2C10A /* CarContourTilesProvider.swift */; };
+		0D6243252FDEC57E00B2C10A /* MaplibreContour in Frameworks */ = {isa = PBXBuildFile; productRef = 0D6243242FDEC57E00B2C10A /* MaplibreContour */; };
 		0DD5D9592FDBDBB300983BAA /* PMTiles in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD5D9582FDBDBB300983BAA /* PMTiles */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
@@ -44,6 +43,7 @@
 		0D46EA122FCC67830033E098 /* PMTilesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PMTilesService.swift; sourceTree = "<group>"; };
 		0D46EA132FCC67830033E098 /* SliceURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliceURLProtocol.swift; sourceTree = "<group>"; };
 		0D46EA1D2FCC68230033E098 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		0D6243212FDEC4F000B2C10A /* CarContourTilesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarContourTilesProvider.swift; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -64,11 +64,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0D4587F02FCE3AAD00269001 /* PMTiles in Frameworks */,
-				0DD5D9562FDBDAF700983BAA /* PMTiles in Frameworks */,
 				A084ECDBA7D38E1E42DFC39D /* Pods_App.framework in Frameworks */,
 				0DD5D9592FDBDBB300983BAA /* PMTiles in Frameworks */,
-				0D46EA052FCC509C0033E098 /* PMTiles in Frameworks */,
+				0D6243252FDEC57E00B2C10A /* MaplibreContour in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +76,7 @@
 		0D46EA0A2FCC67430033E098 /* Car */ = {
 			isa = PBXGroup;
 			children = (
+				0D6243212FDEC4F000B2C10A /* CarContourTilesProvider.swift */,
 				0D46EA0B2FCC67830033E098 /* CarLocationProvider.swift */,
 				0D46EA0C2FCC67830033E098 /* CarMapViewController.swift */,
 				0D46EA0D2FCC67830033E098 /* ReactivePreferencesPlugin.swift */,
@@ -194,6 +193,7 @@
 			mainGroup = 504EC2FB1FED79650016851F;
 			packageReferences = (
 				0DD5D9572FDBDBB300983BAA /* XCRemoteSwiftPackageReference "pmtiles-mobile" */,
+				0D6243232FDEC57E00B2C10A /* XCRemoteSwiftPackageReference "maplibre-contour-rs" */,
 			);
 			productRefGroup = 504EC3051FED79650016851F /* Products */;
 			projectDirPath = "";
@@ -261,6 +261,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0D6243222FDEC4F900B2C10A /* CarContourTilesProvider.swift in Sources */,
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
 				0D46EA142FCC67830033E098 /* CarStatistics.swift in Sources */,
 				0D46EA152FCC67830033E098 /* SliceURLProtocol.swift in Sources */,
@@ -495,55 +496,29 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		0D4587EE2FCE3AAD00269001 /* XCRemoteSwiftPackageReference "pmtiles-mobile" */ = {
+		0D6243232FDEC57E00B2C10A /* XCRemoteSwiftPackageReference "maplibre-contour-rs" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mapeak-com/pmtiles-mobile.git";
+			repositoryURL = "https://github.com/Mapeak-com/maplibre-contour-rs";
 			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-		0D46EA032FCC509C0033E098 /* XCRemoteSwiftPackageReference "swift-pmtiles" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/sfomuseum/swift-pmtiles";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-		0DD5D9542FDBDAF700983BAA /* XCRemoteSwiftPackageReference "pmtiles-mobile" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mapeak-com/pmtiles-mobile.git";
-			requirement = {
-				branch = v0.2.3;
-				kind = branch;
+				kind = exactVersion;
+				version = 0.4.1;
 			};
 		};
 		0DD5D9572FDBDBB300983BAA /* XCRemoteSwiftPackageReference "pmtiles-mobile" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mapeak-com/pmtiles-mobile.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.3;
+				kind = exactVersion;
+				version = 0.3.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0D4587EF2FCE3AAD00269001 /* PMTiles */ = {
+		0D6243242FDEC57E00B2C10A /* MaplibreContour */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0D4587EE2FCE3AAD00269001 /* XCRemoteSwiftPackageReference "pmtiles-mobile" */;
-			productName = PMTiles;
-		};
-		0D46EA042FCC509C0033E098 /* PMTiles */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0D46EA032FCC509C0033E098 /* XCRemoteSwiftPackageReference "swift-pmtiles" */;
-			productName = PMTiles;
-		};
-		0DD5D9552FDBDAF700983BAA /* PMTiles */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0DD5D9542FDBDAF700983BAA /* XCRemoteSwiftPackageReference "pmtiles-mobile" */;
-			productName = PMTiles;
+			package = 0D6243232FDEC57E00B2C10A /* XCRemoteSwiftPackageReference "maplibre-contour-rs" */;
+			productName = MaplibreContour;
 		};
 		0DD5D9582FDBDBB300983BAA /* PMTiles */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/IsraelHiking.Web/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IsraelHiking.Web/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "775e45fde9c60facfe4ff83455bb608ee92c715d14fcb50957bfbbb4baf8f19a",
+  "originHash" : "7608cbab75537ac38f68475d09e70ac6e73fed2e2990687efd2d860d71766c04",
   "pins" : [
+    {
+      "identity" : "maplibre-contour-rs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Mapeak-com/maplibre-contour-rs",
+      "state" : {
+        "revision" : "494aed8b694e8f75abc8958cdf9e05902bc46feb",
+        "version" : "0.4.1"
+      }
+    },
     {
       "identity" : "pmtiles-mobile",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapeak-com/pmtiles-mobile.git",
       "state" : {
-        "revision" : "8fa64bdf47f25aaf08115f5639725b734f6a3b67",
-        "version" : "0.3.1"
+        "revision" : "50237542419cc5c3f61a520e653813c9db1ecc98",
+        "version" : "0.3.2"
       }
     }
   ],

--- a/IsraelHiking.Web/ios/App/App/Car/CarContourTilesProvider.swift
+++ b/IsraelHiking.Web/ios/App/App/Car/CarContourTilesProvider.swift
@@ -1,0 +1,99 @@
+import Foundation
+import MaplibreContour
+
+/**
+ * Generates vector contour tiles on the fly from a terrain (DEM) source, mirroring
+ * `CarContoursTilesProvider.kt` and what maplibre-contour does on the web. The native
+ * maplibre-contour-rs library does the heavy lifting: we hand it a `DemTileFetcher` that downloads a
+ * DEM tile and it returns a ready-to-render MVT for any z/x/y. `SliceURLProtocol` routes contour tile
+ * requests here, passing the units carried in the tile URL.
+ *
+ * Units (metric/imperial) only change the elevation multiplier, so a manager is built and cached per
+ * units string; the managers are thread-safe and shared across requests.
+ */
+final class CarContourTilesProvider {
+
+    private let baseConfig: ContourConfig
+    private let fetcher: DemTileFetcher
+    private let lock = NSLock()
+    private var managers: [String: DemManager] = [:]
+
+    init() {
+        // The layer/attribute names and thresholds must match what the style's contour layers expect
+        // (see the web useContourProtocol in default-style.service.ts, which configures the same values).
+        var config = defaultConfig()
+        config.encoding = .terrarium
+        config.demUrlPattern =
+            "https://global.israelhikingmap.workers.dev/jaxa_terrarium0-11_v2/{z}/{x}/{y}.webp?use=slice"
+        config.demMaxZoom = 11
+        config.overzoom = 1
+        config.thresholds = parseThresholdSpec(spec: "11*200*1000~12*10*100~13*10*100~14*10*100~15*10*100")
+        config.layerName = "contours"
+        config.elevationKey = "ele"
+        config.levelKey = "level"
+        baseConfig = config
+        fetcher = ContourDemTileFetcher()
+    }
+
+    /// Returns the contour MVT for the tile, generated with the multiplier matching `units`.
+    func getTile(z: Int, x: Int, y: Int, units: String) throws -> Data {
+        try manager(for: units).tile(z: UInt8(z), x: UInt32(x), y: UInt32(y))
+    }
+
+    // One manager per units string; metric and imperial differ only by the elevation multiplier.
+    private func manager(for units: String) -> DemManager {
+        lock.lock(); defer { lock.unlock() }
+        if let cached = managers[units] { return cached }
+        var config = baseConfig
+        config.multiplier = Self.multiplier(for: units)
+        let manager = DemManager(fetcher: fetcher, config: config)
+        managers[units] = manager
+        return manager
+    }
+
+    private static func multiplier(for units: String) -> Float {
+        units == unitImperial ? imperialMultiplier : metricMultiplier
+    }
+
+    private static let unitImperial = "imperial"
+    private static let metricMultiplier: Float = 1.0
+    private static let imperialMultiplier: Float = 3.28084
+}
+
+/**
+ * Downloads the raw DEM tile bytes for a fully-resolved URL. The `use=slice` marker in the DEM URL
+ * pattern routes the request through `SliceURLProtocol`, giving DEM fetches the same offline
+ * (PMTiles) fallback the rest of the map enjoys. Returns nil when there is no data, which the library
+ * renders as an empty contour tile.
+ */
+private final class ContourDemTileFetcher: DemTileFetcher, @unchecked Sendable {
+
+    // Routes DEM requests through SliceURLProtocol (offline fallback). DEM URLs carry no `contour`
+    // marker, so SliceURLProtocol serves them as normal slice tiles — no recursion back into contours.
+    private let session: URLSession
+
+    init() {
+        let config = URLSessionConfiguration.ephemeral
+        var protocols: [AnyClass] = [SliceURLProtocol.self]
+        protocols.append(contentsOf: config.protocolClasses ?? [])
+        config.protocolClasses = protocols
+        session = URLSession(configuration: config)
+    }
+
+    // Called synchronously by the native library; block until the tile request completes.
+    func fetch(url: String) -> Data? {
+        guard let requestUrl = URL(string: url) else { return nil }
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Data?
+        let task = session.dataTask(with: requestUrl) { data, response, _ in
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                result = data
+            }
+            semaphore.signal()
+        }
+        task.resume()
+        semaphore.wait()
+        return result
+    }
+}
+

--- a/IsraelHiking.Web/ios/App/App/Car/CarContourTilesProvider.swift
+++ b/IsraelHiking.Web/ios/App/App/Car/CarContourTilesProvider.swift
@@ -2,11 +2,9 @@ import Foundation
 import MaplibreContour
 
 /**
- * Generates vector contour tiles on the fly from a terrain (DEM) source, mirroring
- * `CarContoursTilesProvider.kt` and what maplibre-contour does on the web. The native
+ * Generates vector contour tiles on the fly from a terrain (DEM) source. The native
  * maplibre-contour-rs library does the heavy lifting: we hand it a `DemTileFetcher` that downloads a
- * DEM tile and it returns a ready-to-render MVT for any z/x/y. `SliceURLProtocol` routes contour tile
- * requests here, passing the units carried in the tile URL.
+ * DEM tile and it returns a ready-to-render MVT for any z/x/y.
  *
  * Units (metric/imperial) only change the elevation multiplier, so a manager is built and cached per
  * units string; the managers are thread-safe and shared across requests.
@@ -19,8 +17,6 @@ final class CarContourTilesProvider {
     private var managers: [String: DemManager] = [:]
 
     init() {
-        // The layer/attribute names and thresholds must match what the style's contour layers expect
-        // (see the web useContourProtocol in default-style.service.ts, which configures the same values).
         var config = defaultConfig()
         config.encoding = .terrarium
         config.demUrlPattern =
@@ -40,7 +36,7 @@ final class CarContourTilesProvider {
         try manager(for: units).tile(z: UInt8(z), x: UInt32(x), y: UInt32(y))
     }
 
-    // One manager per units string; metric and imperial differ only by the elevation multiplier.
+    /// Retrieves a DemManager instance for the given units, creating one if necessary.
     private func manager(for units: String) -> DemManager {
         lock.lock(); defer { lock.unlock() }
         if let cached = managers[units] { return cached }
@@ -68,8 +64,6 @@ final class CarContourTilesProvider {
  */
 private final class ContourDemTileFetcher: DemTileFetcher, @unchecked Sendable {
 
-    // Routes DEM requests through SliceURLProtocol (offline fallback). DEM URLs carry no `contour`
-    // marker, so SliceURLProtocol serves them as normal slice tiles — no recursion back into contours.
     private let session: URLSession
 
     init() {
@@ -80,7 +74,7 @@ private final class ContourDemTileFetcher: DemTileFetcher, @unchecked Sendable {
         session = URLSession(configuration: config)
     }
 
-    // Called synchronously by the native library; block until the tile request completes.
+    /// Called synchronously by the native library; block until the tile request completes.
     func fetch(url: String) -> Data? {
         guard let requestUrl = URL(string: url) else { return nil }
         let semaphore = DispatchSemaphore(value: 0)

--- a/IsraelHiking.Web/ios/App/App/Car/SliceURLProtocol.swift
+++ b/IsraelHiking.Web/ios/App/App/Car/SliceURLProtocol.swift
@@ -9,12 +9,14 @@ import Foundation
 final class SliceURLProtocol: URLProtocol {
 
     static let pmTiles = PMTilesService()
+    static let contours = CarContourTilesProvider()
 
     private static let handledKey = "SliceURLProtocolHandled"
     private static let onlineTimeoutMs = 60_000.0
     private static let onlineTimeoutOfflineAvailableMs = 2_000.0
 
     private var dataTask: URLSessionDataTask?
+    private var isStopped = false
     // One shared session for all tile fetches. Ephemeral config carries no custom protocols, so the
     // network fetch can't recurse back into us.
     private static let session = URLSession(configuration: .ephemeral)
@@ -33,6 +35,15 @@ final class SliceURLProtocol: URLProtocol {
     override func startLoading() {
         guard let url = request.url, let parsed = SliceURLProtocol.parse(url) else {
             client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        // The contour source carries a `contour=<units>` marker (see useContourQuery on the web);
+        // there are no offline PMTiles for it, so we generate the MVT locally from the DEM, mirroring
+        // maplibre-contour on the web. The units in the URL also key the tile cache, so a unit change
+        // naturally re-requests fresh tiles.
+        if let units = SliceURLProtocol.contourUnits(url) {
+            serveContour(parsed: parsed, units: units)
             return
         }
 
@@ -64,6 +75,7 @@ final class SliceURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {
+        isStopped = true
         dataTask?.cancel()
         dataTask = nil
     }
@@ -85,6 +97,35 @@ final class SliceURLProtocol: URLProtocol {
         client?.urlProtocol(self, didReceive: offlineResponse, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
         client?.urlProtocolDidFinishLoading(self)
+    }
+
+    private func serveContour(parsed: (type: String, z: Int, x: Int, y: Int), units: String) {
+        // Generating is blocking (it fetches the DEM synchronously), so run it off the loading thread.
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else { return }
+            do {
+                let data = try SliceURLProtocol.contours.getTile(
+                    z: parsed.z, x: parsed.x, y: parsed.y, units: units)
+                guard !self.isStopped else { return }
+                let headers = ["Content-Type": "application/x-protobuf"]
+                let response = HTTPURLResponse(
+                    url: self.request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: headers)!
+                self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                self.client?.urlProtocol(self, didLoad: data)
+                self.client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                guard !self.isStopped else { return }
+                self.client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    /// Reads the `contour=<units>` marker the web adds to the contour source tiles (see useContourQuery).
+    private static func contourUnits(_ url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let items = components.queryItems
+        else { return nil }
+        return items.first { $0.name == "contour" }?.value
     }
 
     /// Parses `.../{type}/{z}/{x}/{y}.ext?use=slice` the same way `SliceProtocolInterceptor.kt` does.

--- a/IsraelHiking.Web/ios/App/App/Car/SliceURLProtocol.swift
+++ b/IsraelHiking.Web/ios/App/App/Car/SliceURLProtocol.swift
@@ -38,10 +38,6 @@ final class SliceURLProtocol: URLProtocol {
             return
         }
 
-        // The contour source carries a `contour=<units>` marker (see useContourQuery on the web);
-        // there are no offline PMTiles for it, so we generate the MVT locally from the DEM, mirroring
-        // maplibre-contour on the web. The units in the URL also key the tile cache, so a unit change
-        // naturally re-requests fresh tiles.
         if let units = SliceURLProtocol.contourUnits(url) {
             serveContour(parsed: parsed, units: units)
             return

--- a/IsraelHiking.Web/ios/App/fastlane/metadata/en-US/release_notes.txt
+++ b/IsraelHiking.Web/ios/App/fastlane/metadata/en-US/release_notes.txt
@@ -1,2 +1,2 @@
-- Add support for CarPlay
+- Add support for CarPlay with dynamic contours
 - Various bug fixes and performance improvements

--- a/IsraelHiking.Web/src/application/components/map/automatic-layer-presentation.component.ts
+++ b/IsraelHiking.Web/src/application/components/map/automatic-layer-presentation.component.ts
@@ -103,7 +103,7 @@ export class AutomaticLayerPresentationComponent implements OnInit, OnChanges, O
     }
 
     private async createLayer(layerData: EditableLayer) {
-        const styleLike = await this.defaultStyleService.getSourcesAndLayers(layerData, this.visible(), this.allowOffline() ? "offline" : "online");
+        const styleLike = await this.defaultStyleService.getSourcesAndLayers(layerData, this.visible(), this.allowOffline() ? "allow-offline" : "online-only");
         this.updateSourcesAndLayers(layerData, styleLike.sources, styleLike.layers);
 
         if (this.isBaselayer()) {

--- a/IsraelHiking.Web/src/application/services/car.service.ts
+++ b/IsraelHiking.Web/src/application/services/car.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from "@angular/core";
 import { registerPlugin } from "@capacitor/core";
 import { Store } from "@ngxs/store";
+import { skip } from "rxjs";
 
 import { RunningContextService } from "./running-context.service";
 import { LoggingService } from "./logging.service";
@@ -35,23 +36,23 @@ export class CarService {
             return;
         }
 
-        this.store.select((state: ApplicationState) => state.layersState.selectedBaseLayerKey).subscribe(() => {
+        this.store.select((state: ApplicationState) => state.layersState.selectedBaseLayerKey).pipe(skip(1)).subscribe(() => {
             this.setStyle();
         });
-        this.store.select((state: ApplicationState) => state.offlineState.downloadedTiles).subscribe(() => {
+        this.store.select((state: ApplicationState) => state.offlineState.downloadedTiles).pipe(skip(1)).subscribe(() => {
             this.setStyle();
         });
-        this.store.select((state: ApplicationState) => state.routes.present).subscribe(() => {
+        this.store.select((state: ApplicationState) => state.routes.present).pipe(skip(1)).subscribe(() => {
             this.setRoutes();
         });
-        this.store.select((state: ApplicationState) => state.configuration.language).subscribe(async () => {
-            await this.setStyle();
+        this.store.select((state: ApplicationState) => state.configuration.language).pipe(skip(1)).subscribe(async () => {
             await this.setConfig();
+            await this.setStyle();
             await this.setRoutes();
         });
-        this.store.select((state: ApplicationState) => state.configuration.units).subscribe(async () => {
-            await this.setStyle();
+        this.store.select((state: ApplicationState) => state.configuration.units).pipe(skip(1)).subscribe(async () => {
             await this.setConfig();
+            await this.setStyle();
         });
         await this.setConfig();
         await this.setStyle();

--- a/IsraelHiking.Web/src/application/services/car.service.ts
+++ b/IsraelHiking.Web/src/application/services/car.service.ts
@@ -49,8 +49,9 @@ export class CarService {
             await this.setConfig();
             await this.setRoutes();
         });
-        this.store.select((state: ApplicationState) => state.configuration.units).subscribe(() => {
-            this.setConfig();
+        this.store.select((state: ApplicationState) => state.configuration.units).subscribe(async () => {
+            await this.setStyle();
+            await this.setConfig();
         });
         await this.setConfig();
         await this.setStyle();

--- a/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
@@ -351,7 +351,7 @@ describe("DefaultStyleService", () => {
         expect(contour.tiles?.[0]).toContain("multiplier=3.28084");
     }));
 
-    it("should append the slice query to the contour source in car mode", inject([DefaultStyleService, FileService], async (service: DefaultStyleService, fileService: FileService) => {
+    it("should tag the contour source with the slice and units query in car mode", inject([DefaultStyleService, FileService], async (service: DefaultStyleService, fileService: FileService) => {
         (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({
             version: 8,
             sources: {
@@ -368,8 +368,30 @@ describe("DefaultStyleService", () => {
         const contour = result.sources.Contour as VectorSourceSpecification;
         expect(contour.url).toBeUndefined();
         expect(contour.tiles?.[0]).not.toContain("dem-contour://");
-        expect(contour.tiles?.[0]).toBe("https://x/{z}/{x}/{y}.pbf?use=slice");
-        expect(contour.maxzoom).toBe(14);
+        expect(contour.tiles?.[0]).toBe("https://x/{z}/{x}/{y}.pbf?use=slice&contour=metric");
+        expect(contour.maxzoom).toBe(16);
+    }));
+
+    it("should tag the contour source with imperial units in car mode when configured", inject([DefaultStyleService, Store, FileService], async (service: DefaultStyleService, store: Store, fileService: FileService) => {
+        store.reset({
+            offlineState: { downloadedTiles: null },
+            configuration: { units: "imperial" }
+        });
+        (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({
+            version: 8,
+            sources: {
+                Contour: { type: "vector", url: "https://x/c.json", tiles: ["https://x/{z}/{x}/{y}.pbf"], maxzoom: 14 }
+            },
+            layers: []
+        }));
+
+        const result = await service.getSourcesAndLayers(createLayer({
+            key: builtInLayerKey,
+            address: "https://x/style.json"
+        }), true, "car");
+
+        const contour = result.sources.Contour as VectorSourceSpecification;
+        expect(contour.tiles?.[0]).toBe("https://x/{z}/{x}/{y}.pbf?use=slice&contour=imperial");
     }));
 
     it("should treat a .json address with a query string as a vector style", inject([DefaultStyleService, FileService], async (service: DefaultStyleService, fileService: FileService) => {

--- a/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
@@ -92,7 +92,7 @@ describe("DefaultStyleService", () => {
             minZoom: 5,
             maxZoom: 15,
             opacity: 0.5
-        }), true, "online");
+        }), true, "online-only");
 
         const layer = result.layers[0] as RasterLayerSpecification;
         const source = result.sources[layer.source] as RasterSourceSpecification;
@@ -117,7 +117,7 @@ describe("DefaultStyleService", () => {
             address: "https://tiles.example.com/{z}/{x}/{y}.png",
             minZoom: 1,
             maxZoom: 10
-        }), false, "online");
+        }), false, "online-only");
 
         const layer = result.layers[0] as RasterLayerSpecification;
         expect(layer.layout?.visibility).toBe("none");
@@ -129,7 +129,7 @@ describe("DefaultStyleService", () => {
             address: "https://server/arcgis/rest/MapServer",
             minZoom: 1,
             maxZoom: 10
-        }), true, "online");
+        }), true, "online-only");
 
         const layer = result.layers[0] as RasterLayerSpecification;
         const source = result.sources[layer.source] as RasterSourceSpecification;
@@ -144,7 +144,7 @@ describe("DefaultStyleService", () => {
             address: "https://server/arcgis/rest/MapServer/3",
             minZoom: 1,
             maxZoom: 10
-        }), true, "online");
+        }), true, "online-only");
 
         const layer = result.layers[0] as RasterLayerSpecification;
         const source = result.sources[layer.source] as RasterSourceSpecification;
@@ -157,7 +157,7 @@ describe("DefaultStyleService", () => {
             address: "https://tiles.example.com/{z}/{x}/{-y}.png",
             minZoom: 1,
             maxZoom: 10
-        }), true, "online");
+        }), true, "online-only");
 
         const layer = result.layers[0] as RasterLayerSpecification;
         const source = result.sources[layer.source] as RasterSourceSpecification;
@@ -171,13 +171,13 @@ describe("DefaultStyleService", () => {
             address: "https://tiles.example.com/a/{z}/{x}/{y}.png",
             minZoom: 1,
             maxZoom: 10
-        }), true, "online");
+        }), true, "online-only");
         const second = await service.getSourcesAndLayers(createLayer({
             key: "raster-key",
             address: "https://tiles.example.com/b/{z}/{x}/{y}.png",
             minZoom: 1,
             maxZoom: 10
-        }), true, "online");
+        }), true, "online-only");
 
         expect(first.layers[0].id).not.toBe(second.layers[0].id);
         expect(Object.keys(first.sources)[0]).not.toBe(Object.keys(second.sources)[0]);
@@ -204,7 +204,7 @@ describe("DefaultStyleService", () => {
         const result = await service.getSourcesAndLayers(createLayer({
             key: builtInLayerKey,
             address: "https://x/style.json"
-        }), true, "online");
+        }), true, "online-only");
 
         const asText = JSON.stringify(result);
         expect(asText).toContain("name:en");
@@ -223,7 +223,7 @@ describe("DefaultStyleService", () => {
         await service.getSourcesAndLayers(createLayer({
             key: builtInLayerKey,
             address: "https://x/style.json"
-        }), true, "online");
+        }), true, "online-only");
 
         expect(fileService.getStyleJsonContent).toHaveBeenCalledWith("https://x/style.json", false);
     }));
@@ -238,7 +238,7 @@ describe("DefaultStyleService", () => {
         await service.getSourcesAndLayers(createLayer({
             key: builtInLayerKey,
             address: "https://x/style.json"
-        }), true, "offline");
+        }), true, "allow-offline");
 
         expect(fileService.getStyleJsonContent).toHaveBeenCalledWith("https://x/style.json", true);
     }));
@@ -256,7 +256,7 @@ describe("DefaultStyleService", () => {
         const result = await service.getSourcesAndLayers(createLayer({
             key: builtInLayerKey,
             address: "https://x/style.json"
-        }), true, "offline");
+        }), true, "allow-offline");
 
         const vector = result.sources.test as VectorSourceSpecification;
         const dem = result.sources.dem as RasterDEMSourceSpecification;
@@ -301,7 +301,7 @@ describe("DefaultStyleService", () => {
         const result = await service.getSourcesAndLayers(createLayer({
             key: "not-a-builtin-layer",
             address: "https://x/style.json"
-        }), true, "offline");
+        }), true, "allow-offline");
 
         const source = result.sources.test as VectorSourceSpecification;
         expect(source.url).toBe("https://x/v.json");
@@ -320,7 +320,7 @@ describe("DefaultStyleService", () => {
         const result = await service.getSourcesAndLayers(createLayer({
             key: builtInLayerKey,
             address: "https://x/style.json"
-        }), true, "offline");
+        }), true, "allow-offline");
 
         const contour = result.sources.Contour as VectorSourceSpecification;
         expect(contour.url).toBeUndefined();
@@ -345,7 +345,7 @@ describe("DefaultStyleService", () => {
         const result = await service.getSourcesAndLayers(createLayer({
             key: builtInLayerKey,
             address: "https://x/style.json"
-        }), true, "offline");
+        }), true, "allow-offline");
 
         const contour = result.sources.Contour as VectorSourceSpecification;
         expect(contour.tiles?.[0]).toContain("multiplier=3.28084");
@@ -376,7 +376,7 @@ describe("DefaultStyleService", () => {
         await service.getSourcesAndLayers(createLayer({
             key: builtInLayerKey,
             address: "https://x/style.json?cache=123"
-        }), true, "online");
+        }), true, "online-only");
 
         expect(fileService.getStyleJsonContent).toHaveBeenCalled();
     }));

--- a/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
@@ -351,7 +351,7 @@ describe("DefaultStyleService", () => {
         expect(contour.tiles?.[0]).toContain("multiplier=3.28084");
     }));
 
-    it("should not manipulate the contour source when not offline", inject([DefaultStyleService, FileService], async (service: DefaultStyleService, fileService: FileService) => {
+    it("should append the slice query to the contour source in car mode", inject([DefaultStyleService, FileService], async (service: DefaultStyleService, fileService: FileService) => {
         (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({
             version: 8,
             sources: {
@@ -366,7 +366,9 @@ describe("DefaultStyleService", () => {
         }), true, "car");
 
         const contour = result.sources.Contour as VectorSourceSpecification;
+        expect(contour.url).toBeUndefined();
         expect(contour.tiles?.[0]).not.toContain("dem-contour://");
+        expect(contour.tiles?.[0]).toBe("https://x/{z}/{x}/{y}.pbf?use=slice");
         expect(contour.maxzoom).toBe(14);
     }));
 

--- a/IsraelHiking.Web/src/application/services/default-style.service.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.ts
@@ -116,53 +116,72 @@ export class DefaultStyleService {
         }
     }
 
-    private manipulateStyle(styleAsText: string, language: string, units: "metric" | "imperial", manupulateSources: "sliceProtocol" | "sliceQuery" | "none", manupulateContour: boolean) {
-        styleAsText = styleAsText.replace(/name:he/g, `name:${language}`);
-        styleAsText = styleAsText.replaceAll("Open Sans", "Noto Sans");
-        const styleJson = JSON.parse(styleAsText) as StyleSpecification;
-        if (manupulateSources !== "none") {
-            for (const source of Object.values(styleJson.sources)) {
-                if (source.type === "vector") {
-                    delete source.url;
-                    if (manupulateSources === "sliceProtocol") {
-                        source.tiles[0] = source.tiles[0].replace("https://", "slice://");
-                    } else {
-                        source.tiles[0] += "?use=slice";
-                    }
-                }
-                if (source.type === "raster-dem") {
-                    delete source.url;
-                    if (manupulateSources === "sliceProtocol") {
-                        source.tiles[0] = source.tiles[0].replace("https://", "slice://");
-                    } else {
-                        source.tiles[0] += "?use=slice";
-                    }
-                }
+    private useSliceQuery(styleJson: StyleSpecification) {
+        for (const source of Object.values(styleJson.sources)) {
+            if (source.type === "vector") {
+                delete source.url;
+                source.tiles[0] += "?use=slice";
+            }
+            if (source.type === "raster-dem") {
+                delete source.url;
+                source.tiles[0] += "?use=slice";
             }
         }
-        if (manupulateContour && styleJson.sources["Contour"]?.type === "vector") {
-            const contourSource = styleJson.sources["Contour"];
-            const multiplier = units === "metric" ? 1 : 3.28084;
-            delete contourSource.url;
-            contourSource.tiles[0] = `dem-contour://{z}/{x}/{y}?contourLayer=contours&elevationKey=ele&levelKey=level&multiplier=${multiplier}&overzoom=1&thresholds=11*200*1000~12*10*100~13*10*100~14*10*100~15*10*100`
-            contourSource.maxzoom = 16;
-        }
-
-        return styleJson;
     }
 
-    public async getSourcesAndLayers(layerData: EditableLayer, isVisible: boolean, mode: "online" | "offline" | "car"): Promise<StyleSpecification> {
+    private useSliceProtocol(styleJson: StyleSpecification) {
+        for (const source of Object.values(styleJson.sources)) {
+            if (source.type === "vector") {
+                delete source.url;
+                source.tiles[0] = source.tiles[0].replace("https://", "slice://");
+            }
+            if (source.type === "raster-dem") {
+                delete source.url;
+                source.tiles[0] = source.tiles[0].replace("https://", "slice://");
+            }
+        }
+    }
+
+    private useContourProtocol(styleJson: StyleSpecification, units: "metric" | "imperial") {
+        if (styleJson.sources["Contour"]?.type !== "vector") {
+            return;
+        }
+        const contourSource = styleJson.sources["Contour"];
+        const multiplier = units === "metric" ? 1 : 3.28084;
+        delete contourSource.url;
+        contourSource.tiles[0] = `dem-contour://{z}/{x}/{y}?contourLayer=contours&elevationKey=ele&levelKey=level&multiplier=${multiplier}&overzoom=1&thresholds=11*200*1000~12*10*100~13*10*100~14*10*100~15*10*100`
+        contourSource.maxzoom = 16;
+    }
+
+    public async getSourcesAndLayers(layerData: EditableLayer, isVisible: boolean, mode: "online-only" | "allow-offline" | "car"): Promise<StyleSpecification> {
         if (this.isRaster(layerData.address)) {
             return this.createRasterLayer(layerData, isVisible);
         } else {
             const isBuiltInBaseLayer = DEFAULT_BASE_LAYERS.some(l => l.key === layerData.key);
-            const tryLocalStyle = mode !== "online" && isBuiltInBaseLayer && this.store.selectSnapshot((s: ApplicationState) => s.offlineState).downloadedTiles != null;
+            const tryLocalStyle = mode !== "online-only" && isBuiltInBaseLayer && this.store.selectSnapshot((s: ApplicationState) => s.offlineState).downloadedTiles != null;
             const language = this.resources.getCurrentLanguageCodeSimplified();
             const units = this.store.selectSnapshot((s: ApplicationState) => s.configuration.units);
 
-            const styleAsText = await this.fileService.getStyleJsonContent(layerData.address, tryLocalStyle);
-            const manupulateSources = mode === "online" || !isBuiltInBaseLayer ? "none" : mode === "car" ? "sliceQuery" : "sliceProtocol";
-            const styleJson = this.manipulateStyle(styleAsText, language, units, manupulateSources, mode === "offline");
+            let styleAsText = await this.fileService.getStyleJsonContent(layerData.address, tryLocalStyle);
+            styleAsText = styleAsText.replace(/name:he/g, `name:${language}`);
+            styleAsText = styleAsText.replaceAll("Open Sans", "Noto Sans");
+            const styleJson = JSON.parse(styleAsText) as StyleSpecification;
+            switch (mode) {
+                case "online-only":
+                    this.useContourProtocol(styleJson, units);
+                    break;
+                case "allow-offline":
+                    if (isBuiltInBaseLayer) {
+                        this.useSliceProtocol(styleJson);
+                    }
+                    this.useContourProtocol(styleJson, units);
+                    break;
+                case "car":
+                    if (isBuiltInBaseLayer) {
+                        this.useSliceQuery(styleJson);
+                    }
+                    break;
+            }
             return styleJson;
         }
     }

--- a/IsraelHiking.Web/src/application/services/default-style.service.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.ts
@@ -158,9 +158,6 @@ export class DefaultStyleService {
             return;
         }
         const contourSource = styleJson.sources["Contour"];
-        // The car generates contours natively (see CarContoursTilesProvider). useSliceQuery already
-        // tagged the tiles with ?use=slice; the units are appended so a unit change yields a distinct
-        // URL that busts the tile cache, mirroring the multiplier in the web dem-contour:// URL.
         contourSource.tiles[0] += `&contour=${units}`;
         contourSource.maxzoom = 16;
     }

--- a/IsraelHiking.Web/src/application/services/default-style.service.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.ts
@@ -153,6 +153,18 @@ export class DefaultStyleService {
         contourSource.maxzoom = 16;
     }
 
+    private useContourQuery(styleJson: StyleSpecification, units: "metric" | "imperial") {
+        if (styleJson.sources["Contour"]?.type !== "vector") {
+            return;
+        }
+        const contourSource = styleJson.sources["Contour"];
+        // The car generates contours natively (see CarContoursTilesProvider). useSliceQuery already
+        // tagged the tiles with ?use=slice; the units are appended so a unit change yields a distinct
+        // URL that busts the tile cache, mirroring the multiplier in the web dem-contour:// URL.
+        contourSource.tiles[0] += `&contour=${units}`;
+        contourSource.maxzoom = 16;
+    }
+
     public async getSourcesAndLayers(layerData: EditableLayer, isVisible: boolean, mode: "online-only" | "allow-offline" | "car"): Promise<StyleSpecification> {
         if (this.isRaster(layerData.address)) {
             return this.createRasterLayer(layerData, isVisible);
@@ -179,6 +191,8 @@ export class DefaultStyleService {
                 case "car":
                     if (isBuiltInBaseLayer) {
                         this.useSliceQuery(styleJson);
+                        this.useContourQuery(styleJson, units);
+                        console.log(styleJson);
                     }
                     break;
             }


### PR DESCRIPTION
- Resolves #2535

This uses the maplibre-contour-rs package that can work for both iOS and Android.

This brings the imperial contours to the car display. It replaces the usage of the online ones, which should allow for complete offline mode when it comes to map viewing.

