### PR TITLE
Relevance: rank search by proximity + prominence + feature class (query-side, no reindex)

### DIFF
--- a/IsraelHiking.API/Controllers/SearchController.cs
+++ b/IsraelHiking.API/Controllers/SearchController.cs
@@ -20,10 +20,7 @@ public class SearchController : ControllerBase
 {
     private readonly ISearchRepository _searchRepository;
 
-    /// <summary>
-    /// Controller's constructor
-    /// </summary>
-    /// <param name="searchRepository"></param>
+    /// <summary>Controller's constructor</summary>
     public SearchController(ISearchRepository searchRepository)
     {
         _searchRepository = searchRepository;
@@ -35,11 +32,16 @@ public class SearchController : ControllerBase
     /// <remarks>Searches for geolocations (points of interest) matching the given term in the given language.</remarks>
     /// <param name="term">A string to search for</param>
     /// <param name="language">The language to search in</param>
+    /// <param name="lat">Optional map center latitude — biases results toward this point</param>
+    /// <param name="lng">Optional map center longitude — biases results toward this point</param>
+    /// <param name="zoom">Optional map zoom level — controls how tight the proximity bias is</param>
+    /// <param name="prefix">True when the user is mid-typing (autocomplete) — favours prefix matches</param>
     /// <returns></returns>
-    // GET api/search/abc&language=en
     [HttpGet]
     [Route("{term}")]
-    public async Task<IEnumerable<SearchResultsPointOfInterest>> GetSearchResults(string term, string language)
+    public async Task<IEnumerable<SearchResultsPointOfInterest>> GetSearchResults(string term, string language,
+        [FromQuery] double? lat = null, [FromQuery] double? lng = null,
+        [FromQuery] double? zoom = null, [FromQuery] bool prefix = false)
     {
         if ((term.StartsWith("\"") || term.StartsWith("״")) &&
             (term.EndsWith("\"") || term.EndsWith("״")))
@@ -50,7 +52,7 @@ public class SearchController : ControllerBase
 
         if (term.Count(c => c == ',') == 1)
         {
-            var featuresWithinPlaces = await _searchRepository.SearchPlaces(term, language);
+            var featuresWithinPlaces = await _searchRepository.SearchPlaces(term, language, lat, lng, zoom, prefix);
             if (featuresWithinPlaces.Count != 0)
             {
                 return await Task.WhenAll(featuresWithinPlaces.ToList().Select(ConvertFromFeature));
@@ -58,7 +60,7 @@ public class SearchController : ControllerBase
             term = term.Split(",").First().Trim();
         }
 
-        var features = await _searchRepository.Search(term, language);
+        var features = await _searchRepository.Search(term, language, lat, lng, zoom, prefix);
         return await Task.WhenAll(features.ToList().Select(ConvertFromFeature));
     }
 

--- a/IsraelHiking.Common/Poi/SearchResultsPointOfInterest.cs
+++ b/IsraelHiking.Common/Poi/SearchResultsPointOfInterest.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace IsraelHiking.Common.Poi;
 

--- a/IsraelHiking.DataAccess/ElasticSearch/ElasticSearchGateway.cs
+++ b/IsraelHiking.DataAccess/ElasticSearch/ElasticSearchGateway.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
@@ -51,68 +53,84 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
         logger.LogInformation("Finished initialing elasticsearch with uri: " + uri);
     }
 
-    /// <summary>
-    /// This method is used to extract the field with the highest contribution to the score
-    /// It uses the explanation object to recursively find the field
-    /// </summary>
-    /// <param name="exp"></param>
-    /// <returns></returns>
-    private string FindBestField(ExplanationDetail exp)
+    private static readonly Dictionary<string, (string Icon, string Color)> _featureClassIcon = new()
     {
-        // Extract the field from the explanation
-        var match = Regex.Match(exp.Description, @"weight\((.*)\)");
-        if (match.Success)
-        {
-            return match.Groups[1].Value;
-        }
+        ["peak"] = ("icon-peak", "black"), ["hill"] = ("icon-peak", "black"),
+        ["ridge"] = ("icon-peak", "black"), ["saddle"] = ("icon-peak", "black"),
+        ["cliff"] = ("icon-peak", "black"), ["rock"] = ("icon-peak", "black"),
+        ["canyon"] = ("icon-peak", "black"), ["plateau"] = ("icon-peak", "black"),
+        ["arch"] = ("icon-peak", "black"), ["cave"] = ("icon-peak", "black"),
+        ["lake"] = ("icon-tint", "#1e80e3"), ["reservoir"] = ("icon-tint", "#1e80e3"),
+        ["pond"] = ("icon-tint", "#1e80e3"), ["spring"] = ("icon-tint", "#1e80e3"),
+        ["wetland"] = ("icon-tint", "#1e80e3"),
+        ["river"] = ("icon-river", "#1e80e3"), ["stream"] = ("icon-river", "#1e80e3"),
+        ["canal"] = ("icon-river", "#1e80e3"), ["rapids"] = ("icon-river", "#1e80e3"),
+        ["waterfall"] = ("icon-waterfall", "#1e80e3"),
+        ["glacier"] = ("icon-tint", "#1e80e3"),
+        ["bay"] = ("icon-anchor", "#1e80e3"), ["cape"] = ("icon-anchor", "#1e80e3"),
+        ["beach"] = ("icon-anchor", "#1e80e3"), ["island"] = ("icon-anchor", "#1e80e3"),
+        ["forest"] = ("icon-tree", "#008000"),
+        ["viewpoint"] = ("icon-viewpoint", "#008000"), ["campsite"] = ("icon-campsite", "#734a08"),
+        ["attraction"] = ("icon-star", "#ffb800"),
+        ["city"] = ("icon-home", "black"), ["town"] = ("icon-home", "black"),
+        ["village"] = ("icon-home", "black"), ["hamlet"] = ("icon-home", "black"),
+        ["suburb"] = ("icon-home", "black"), ["neighbourhood"] = ("icon-home", "black"),
+        ["locality"] = ("icon-home", "black"),
+        ["lodging"] = ("icon-bed", "black"),
+        ["food"] = ("icon-cutlery", "black"),
+        ["shop"] = ("icon-shopping-cart", "black"),
+        ["museum"] = ("icon-camera", "black"),
+        ["religious"] = ("icon-church", "black"),
+        ["education"] = ("icon-graduation-cap", "black"),
+        ["medical"] = ("icon-medkit", "#d00"),
+        ["government"] = ("icon-bank", "black"),
+        ["sports"] = ("icon-flag", "#008000"),
+        ["park"] = ("icon-tree", "#008000"),
+        ["fuel"] = ("icon-automobile", "black"),
+        ["parking"] = ("icon-parking", "black"),
+        ["transit"] = ("icon-bus", "black"),
+        ["office"] = ("icon-building", "black"),
+        ["structure"] = ("icon-building", "black"),
+        ["building"] = ("icon-building", "black"),
+    };
 
-        // Recursively check child explanations
-        foreach (var child in exp.Details)
+    private List<IFeature> HitsToFeatures(ISearchResponse<PointDocument> response, string language)
+    {
+        var usable = response.Hits.Where(HasUsableLocation).ToList();
+        var skipped = response.Hits.Count - usable.Count;
+        if (skipped > 0)
         {
-            var childResult = FindBestField(child);
-            if (!string.IsNullOrEmpty(childResult))
-                return childResult;
+            logger.LogWarning("Skipped {Skipped} search hit(s) with a missing or malformed location", skipped);
         }
-
-        return null;
+        return usable.Select(d => HitToFeature(d, language)).ToList();
     }
 
-    /// <summary>
-    /// This method is used to find the language with the highest contribution to the score
-    /// </summary>
-    /// <param name="explanation">The explanination object from the query results</param>
-    /// <param name="fallbackLanguage">The language to use in case no matching language was found</param>
-    /// <returns></returns>
-    private string GetBestMatchLanguage(Explanation explanation, string fallbackLanguage)
-    {
-        // Recursive method to find the field with the highest contribution to the score
-        foreach (var details in explanation?.Details ?? [])
-        {
-            var results = FindBestField(details);
-            if (!string.IsNullOrEmpty(results) && Languages.ArrayWithDefault.Any(l => results.Contains("." + l)))
-            {
-                return Languages.ArrayWithDefault.First(l => results.Contains("." + l));
-            }
-        }
-        return fallbackLanguage;
-    }
+    private static bool HasUsableLocation(IHit<PointDocument> hit) =>
+        hit.Source?.Location is { Length: >= 2 };
 
     private IFeature HitToFeature(IHit<PointDocument> d, string language)
     {
+        var icon = d.Source.PoiIcon;
+        var iconColor = d.Source.PoiIconColor;
+        if (!string.IsNullOrWhiteSpace(d.Source.FeatureClass) &&
+            _featureClassIcon.TryGetValue(d.Source.FeatureClass, out var fc))
+        {
+            icon = fc.Icon;
+            iconColor = fc.Color;
+        }
         IFeature feature = new Feature(new Point(d.Source.Location[0], d.Source.Location[1]), new AttributesTable
         {
             { FeatureAttributes.NAME, d.Source.Name.GetValueOrDefault(Languages.DEFAULT, string.Empty) },
             { FeatureAttributes.POI_SOURCE, d.Source.PoiSource },
-            { FeatureAttributes.POI_ICON, d.Source.PoiIcon },
+            { FeatureAttributes.POI_ICON, icon },
             { FeatureAttributes.POI_CATEGORY, d.Source.PoiCategory },
-            { FeatureAttributes.POI_ICON_COLOR, d.Source.PoiIconColor },
+            { FeatureAttributes.POI_ICON_COLOR, iconColor },
             { FeatureAttributes.DESCRIPTION, d.Source.Description.GetValueOrDefault(Languages.DEFAULT, string.Empty) },
             { FeatureAttributes.POI_ID, d.Id },
             { FeatureAttributes.POI_LANGUAGE, Languages.ALL },
             { FeatureAttributes.ID, string.Join("_", d.Id.Split("_").Skip(1)) }
         });
-        var searchTermLanguage = GetBestMatchLanguage(d.Explanation, language);
-        // This is a bit of a hack to store the lagnuage that the search found on the feature itself...
+        var searchTermLanguage = SearchLanguageDetector.GetBestMatchLanguage(d.MatchedQueries, language);
         feature.Attributes.AddOrUpdate(FeatureAttributes.SEARCH_LANGUAGE, searchTermLanguage);
         foreach (var key in d.Source.Name.Keys.Where(k => k != Languages.DEFAULT))
         {
@@ -122,6 +140,19 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
         {
             feature.Attributes.AddOrUpdate("description:" + key, d.Source.Description[key]);
         }
+        if (d.Source.AltNames != null)
+        {
+            foreach (var key in d.Source.AltNames.Keys)
+            {
+                var values = d.Source.AltNames[key];
+                if (values == null || values.Count == 0)
+                {
+                    continue;
+                }
+                var attrKey = key == Languages.DEFAULT ? "alt_name" : "alt_name:" + key;
+                feature.Attributes.AddOrUpdate(attrKey, string.Join("; ", values));
+            }
+        }
         if (!string.IsNullOrWhiteSpace(d.Source.Image))
         {
             feature.Attributes.AddOrUpdate(FeatureAttributes.IMAGE_URL, d.Source.Image);
@@ -130,54 +161,242 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
         return feature;
     }
 
-    private QueryContainer DocumentNameSearchQuery<T>(QueryContainerDescriptor<T> q, string searchTerm) where T : class
+    private const double EXACT_KEYWORD_BOOST = 12;
+    private const double PREFIX_TIER_BOOST = 12;
+    private const double PHRASE_PREFIX_BOOST = 8;
+    private const double NAME_MATCH_BOOST = 5;
+    private const double FUZZY_TIER_BOOST = 2;
+
+    private const double EXACT_ALT_KEYWORD_BOOST = 6;
+    private const double ALT_NAME_MATCH_BOOST = 3;
+
+    private QueryContainer DocumentNameSearchQuery<T>(QueryContainerDescriptor<T> q, string searchTerm, bool prefix = false) where T : class
     {
-        return q.Bool(b => b
-            .Should(
-                // Tier 1: Exact keyword match — constant score, always wins
-                sh => sh.ConstantScore(cs => cs
-                    .Boost(100)
-                    .Filter(f => f.MultiMatch(m =>
-                        m.Type(TextQueryType.Phrase)
-                        .Query(searchTerm)
-                        .Fields(f2 => f2.Fields(
-                            Languages.ArrayWithDefault.Select(l => new Field("name." + l + ".keyword"))))
-                    ))
-                ),
+        Func<QueryContainerDescriptor<T>, QueryContainer> phrasePrefixQuery = sh => sh.MultiMatch(m =>
+            m.Type(TextQueryType.PhrasePrefix)
+            .Query(searchTerm)
+            .MaxExpansions(200)
+            .Boost(PHRASE_PREFIX_BOOST)
+            .Fields(f => f.Fields(
+                Languages.ArrayWithDefault.Select(l => new Field("name." + l)))));
 
-                // Tier 2: Prefix / "starts with"
-                sh => sh.MultiMatch(m =>
-                    m.Type(TextQueryType.PhrasePrefix)
-                    .Query(searchTerm)
-                    .Boost(8)
-                    .Fields(f => f.Fields(
-                        Languages.ArrayWithDefault.Select(l => new Field("name." + l))))
-                ),
-
-                // Tier 3: Catches substrings that the standard analyzer tokenizes as words
-                sh => sh.MultiMatch(m =>
+        var shoulds = new List<Func<QueryContainerDescriptor<T>, QueryContainer>>
+        {
+            sh => sh.ConstantScore(cs => cs
+                .Boost(EXACT_KEYWORD_BOOST)
+                .Filter(f => f.MultiMatch(m =>
                     m.Type(TextQueryType.Phrase)
                     .Query(searchTerm)
-                    .Boost(5)
-                    .Fields(f => f.Fields(
-                        Languages.ArrayWithDefault.Select(l => new Field("name." + l))))
-                ),
+                    .Fields(f2 => f2.Fields(
+                        Languages.ArrayWithDefault.Select(l => new Field("name." + l + ".keyword"))))
+                ))
+            ),
 
-                // Tier 4: Fuzzy — only kicks in when nothing above matched
-                sh => sh.MultiMatch(m =>
-                    m.Type(TextQueryType.BestFields)
+            prefix
+                ? sh => sh.DisMax(dm => dm
+                    .TieBreaker(0.0)
+                    .Queries(
+                        qq => qq.DisMax(inner => inner
+                            .TieBreaker(0.0)
+                            .Boost(PREFIX_TIER_BOOST)
+                            .Queries(Languages.ArrayWithDefault.Select<string, Func<QueryContainerDescriptor<T>, QueryContainer>>(
+                                l => qi => qi.Match(m => m
+                                    .Field(new Field("name." + l + ".prefix"))
+                                    .Query(searchTerm))).ToArray())),
+                        phrasePrefixQuery))
+                : phrasePrefixQuery
+        };
+
+        shoulds.Add(sh => sh.DisMax(dm => dm
+            .TieBreaker(0.0)
+            .Queries(Languages.ArrayWithDefault.Select<string, Func<QueryContainerDescriptor<T>, QueryContainer>>(
+                l => qq => qq.Match(m => m
+                    .Field(new Field("name." + l))
                     .Query(searchTerm)
-                    .Fuzziness(Fuzziness.Auto)
-                    .Boost(2)
-                    .Fields(f => f.Fields(
-                        Languages.ArrayWithDefault.Select(l => new Field("name." + l))))
-                )
-            )
+                    .Boost(NAME_MATCH_BOOST)
+                    .Name(SearchLanguageDetector.LanguageQueryName(l)))).ToArray())));
+
+        shoulds.Add(sh => sh.ConstantScore(cs => cs
+            .Boost(EXACT_ALT_KEYWORD_BOOST)
+            .Filter(f => f.MultiMatch(m =>
+                m.Type(TextQueryType.Phrase)
+                .Query(searchTerm)
+                .Fields(f2 => f2.Fields(
+                    Languages.ArrayWithDefault.Select(l => new Field("alt_names." + l + ".keyword"))))
+            ))
+        ));
+
+        shoulds.Add(sh => sh.DisMax(dm => dm
+            .TieBreaker(0.0)
+            .Queries(Languages.ArrayWithDefault.Select<string, Func<QueryContainerDescriptor<T>, QueryContainer>>(
+                l => qq => qq.Match(m => m
+                    .Field(new Field("alt_names." + l))
+                    .Query(searchTerm)
+                    .Boost(ALT_NAME_MATCH_BOOST))).ToArray())));
+
+        if (!prefix)
+        {
+            shoulds.Add(sh => sh.MultiMatch(m =>
+                m.Type(TextQueryType.BestFields)
+                .Query(searchTerm)
+                .Fuzziness(Fuzziness.Auto)
+                .Boost(FUZZY_TIER_BOOST)
+                .Fields(f => f.Fields(
+                    Languages.ArrayWithDefault.Select(l => new Field("name." + l))))));
+        }
+
+        return q.Bool(b => b
+            .Should(shoulds.ToArray())
             .MinimumShouldMatch(1)
         );
     }
 
-    public async Task<List<IFeature>> Search(string searchTerm, string language)
+    private QueryContainer NameSearchWithScoring<T>(QueryContainerDescriptor<T> q, string searchTerm,
+        double? lat, double? lng, double? zoom, bool prefix) where T : PointDocument
+    {
+        var center = ResolveMapCenter(lat, lng);
+
+        return q.FunctionScore(fs => fs
+            .Query(qq => DocumentNameSearchQuery(qq, searchTerm, prefix))
+            .ScoreMode(FunctionScoreMode.Sum)
+            .BoostMode(FunctionBoostMode.Replace)
+            .Functions(fns => BuildScoreFunctions(fns, searchTerm, center, zoom))
+        );
+    }
+
+    private static IPromise<IList<IScoreFunction>> BuildScoreFunctions<T>(ScoreFunctionsDescriptor<T> fns,
+        string searchTerm, (double lat, double lng)? center, double? zoom) where T : PointDocument
+    {
+        fns.ScriptScore(ss => ss.Script(s => s
+            .Source("params.w_text * (_score / (_score + params.k_text))")
+            .Params(new Dictionary<string, object>
+            {
+                ["w_text"] = WEIGHT_TEXT,
+                ["k_text"] = TEXT_NORM_K,
+            })));
+
+        fns.FieldValueFactor(fv => fv
+            .Field(PROMINENCE_FIELD)
+            .Missing(0)
+            .Factor(WEIGHT_PROMINENCE));
+
+        var exactNameClauses = Languages.ArrayWithDefault
+            .Select(language => (language, normalized: NormalizeForKeyword(searchTerm, isHebrew: language == Languages.HEBREW)))
+            .Where(x => !string.IsNullOrEmpty(x.normalized))
+            .Select<(string language, string normalized), Func<QueryContainerDescriptor<T>, QueryContainer>>(
+                x => f => f.Term("name." + x.language + ".keyword", x.normalized))
+            .ToArray();
+        if (exactNameClauses.Length > 0)
+        {
+            fns.Weight(w => w
+                .Filter(f => f.Bool(b => b.Should(exactNameClauses).MinimumShouldMatch(1)))
+                .Weight(EXACT_NAME_BONUS));
+        }
+
+        if (center is not { } mapCenter)
+        {
+            return fns;
+        }
+
+        var beta = ZoomBeta(zoom);
+        var (scaleKm, offsetKm) = ComputeGeoDecayParams(zoom);
+
+        fns.GaussGeoLocation(g => g
+            .Field(LOCATION_FIELD)
+            .Origin(new GeoLocation(mapCenter.lat, mapCenter.lng))
+            .Scale(new Distance(scaleKm, DistanceUnit.Kilometers))
+            .Offset(new Distance(offsetKm, DistanceUnit.Kilometers))
+            .Decay(GEO_DECAY)
+            .Weight(WEIGHT_GEO * beta));
+
+        var (halfLatDeg, halfLngDeg) = ComputeViewportHalfExtentDeg(ResolveZoom(zoom), mapCenter.lat);
+        var boxTop = Math.Min(MAX_LATITUDE, mapCenter.lat + halfLatDeg);
+        var boxBottom = Math.Max(MIN_LATITUDE, mapCenter.lat - halfLatDeg);
+        var boxLeft = Math.Max(MIN_LONGITUDE, mapCenter.lng - halfLngDeg);
+        var boxRight = Math.Min(MAX_LONGITUDE, mapCenter.lng + halfLngDeg);
+        fns.Weight(w => w
+            .Filter(f => f.GeoBoundingBox(bb => bb
+                .Field(LOCATION_FIELD)
+                .BoundingBox(b => b
+                    .TopLeft(boxTop, boxLeft)
+                    .BottomRight(boxBottom, boxRight))))
+            .Weight(VIEWPORT_BOOST * beta * beta));
+
+        return fns;
+    }
+
+    internal static (double lat, double lng)? ResolveMapCenter(double? lat, double? lng)
+    {
+        if (lat is not { } latitude || lng is not { } longitude)
+        {
+            return null;
+        }
+        if (double.IsNaN(latitude) || double.IsNaN(longitude) ||
+            double.IsInfinity(latitude) || double.IsInfinity(longitude) ||
+            latitude is < MIN_LATITUDE or > MAX_LATITUDE ||
+            longitude is < MIN_LONGITUDE or > MAX_LONGITUDE)
+        {
+            return null;
+        }
+        return (latitude, longitude);
+    }
+
+    private const double VIEWPORT_BOOST = 0.15;
+
+    private const string LOCATION_FIELD = "location";
+    private const string PROMINENCE_FIELD = "poiProminence";
+
+    private const double WEIGHT_TEXT = 0.5;
+    private const double WEIGHT_GEO = 1.0;
+    private const double WEIGHT_PROMINENCE = 0.3;
+    private const double EXACT_NAME_BONUS = 0.10;
+
+    private const double TEXT_NORM_K = 20.0;
+
+    private const double BETA_MIDPOINT = 8.0;
+    private const double BETA_STEEPNESS = 0.7;
+
+    private static readonly double GEO_DECAY = Math.Exp(-0.5);
+
+    internal static double ZoomBeta(double? zoom) =>
+        1.0 / (1.0 + Math.Exp(-BETA_STEEPNESS * (ResolveZoom(zoom) - BETA_MIDPOINT)));
+
+    private const double KM_PER_DEGREE_LATITUDE = 111.0;
+
+    private static (double halfLatDeg, double halfLngDeg) ComputeViewportHalfExtentDeg(double zoom, double lat)
+    {
+        var (_, offsetKm) = ComputeGeoDecayParams(zoom);
+        var halfKm = Math.Clamp(offsetKm * 3.0, 5.0, 400.0);
+        var halfLatDeg = halfKm / KM_PER_DEGREE_LATITUDE;
+        var cos = Math.Max(0.2, Math.Cos(lat * Math.PI / 180.0));
+        var halfLngDeg = halfKm / (KM_PER_DEGREE_LATITUDE * cos);
+        return (halfLatDeg, halfLngDeg);
+    }
+
+    private const double DEFAULT_ZOOM = 12;
+
+    private const double MAX_ZOOM = 22;
+
+    private const double MIN_LATITUDE = -90;
+    private const double MAX_LATITUDE = 90;
+    private const double MIN_LONGITUDE = -180;
+    private const double MAX_LONGITUDE = 180;
+
+    internal static double ResolveZoom(double? zoom) =>
+        zoom is not { } value || double.IsNaN(value) || value <= 0
+            ? DEFAULT_ZOOM
+            : Math.Min(value, MAX_ZOOM);
+
+    internal static (double scaleKm, double offsetKm) ComputeGeoDecayParams(double? zoom)
+    {
+        var resolvedZoom = ResolveZoom(zoom);
+        var offsetKm = Math.Pow(2.2, 18 - resolvedZoom) * 0.1;
+        var scaleKm = Math.Max(8.0, 0.4 * (resolvedZoom - 3));
+        return (Math.Round(scaleKm, 3), Math.Round(offsetKm, 3));
+    }
+
+    public async Task<List<IFeature>> Search(string searchTerm, string language,
+        double? lat = null, double? lng = null, double? zoom = null, bool prefix = false)
     {
         if (string.IsNullOrWhiteSpace(searchTerm))
         {
@@ -189,10 +408,29 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
             .Size(NUMBER_OF_RESULTS)
             .TrackScores()
             .Sort(f => f.Descending("_score"))
-            .Query(q => DocumentNameSearchQuery(q, searchTerm))
-            .Explain()
+            .Query(q => NameSearchWithScoring(q, searchTerm, lat, lng, zoom, prefix))
         );
-        return response.Hits.Select(d => HitToFeature(d, language)).ToList();
+        LogIfScoredQueryFailed(response, nameof(Search), searchTerm);
+        return HitsToFeatures(response, language);
+    }
+
+    private void LogIfScoredQueryFailed<T>(ISearchResponse<T> response, string operation, string searchTerm) where T : class
+    {
+        if (!response.IsValid)
+        {
+            var reason = response.ServerError?.ToString()
+                ?? response.OriginalException?.ToString()
+                ?? "unknown failure (no ServerError, no OriginalException)";
+            logger.LogError("Scored {Operation}('{Term}') failed: {Err}", operation, searchTerm, reason);
+            return;
+        }
+        var shards = response.Shards;
+        if (shards is not null && shards.Failed > 0)
+        {
+            logger.LogWarning(
+                "Scored {Operation}('{Term}') succeeded on {Successful}/{Total} shards; {Failed} failed, results are partial",
+                operation, searchTerm, shards.Successful, shards.Total, shards.Failed);
+        }
     }
 
     public async Task<List<IFeature>> SearchExact(string searchTerm, string language)
@@ -205,19 +443,21 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
         var response = await _elasticClient.SearchAsync<PointDocument>(s => s.Index(POINTS)
             .Size(NUMBER_OF_RESULTS)
             .TrackScores()
-            .Sort(f => f.Descending("_score"))
-            .Query(q =>
-                q.MultiMatch(m =>
-                    m.Type(TextQueryType.Phrase)
+            .Sort(f => f.Descending("_score").Field(ff => ff.Field("poiProminence").Descending().UnmappedType(FieldType.Float)))
+            .Query(q => q.DisMax(dm => dm
+                .TieBreaker(0.0)
+                .Queries(Languages.ArrayWithDefault.Select<string, Func<QueryContainerDescriptor<PointDocument>, QueryContainer>>(
+                    l => qq => qq.MatchPhrase(mp => mp
+                        .Field(new Field("name." + l + ".keyword"))
                         .Query(searchTerm)
-                        .Fields(f => f.Fields(Languages.ArrayWithDefault.Select(l => new Field("name." + l + ".keyword"))))
-                )
-            ).Explain()
+                        .Name(SearchLanguageDetector.LanguageQueryName(l)))).ToArray())))
         );
-        return response.Hits.Select(d => HitToFeature(d, language)).ToList();
+        LogIfScoredQueryFailed(response, nameof(SearchExact), searchTerm);
+        return HitsToFeatures(response, language);
     }
 
-    public async Task<List<IFeature>> SearchPlaces(string searchTerm, string language)
+    public async Task<List<IFeature>> SearchPlaces(string searchTerm, string language,
+        double? lat = null, double? lng = null, double? zoom = null, bool prefix = false)
     {
         var split = searchTerm.Split(',');
         var place = NormalizeSearchTerm(split.Last().Trim());
@@ -227,11 +467,26 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
             return [];
         }
         var placesResponse = await _elasticClient.SearchAsync<BBoxDocument>(s => s.Index(BBOX)
-            .Size(1)
+            .Size(20)
             .TrackScores()
-            .Sort(f => f.Descending("_score"))
-            .Query(q => DocumentNameSearchQuery(q, place))
+            .Sort(f => f.Descending(a => a.Area))
+            .Query(q => q.MultiMatch(m => m
+                .Type(TextQueryType.Phrase)
+                .Query(place)
+                .Fields(f2 => f2.Fields(
+                    Languages.ArrayWithDefault.Select(l => new Field("name." + l))))))
         );
+        LogIfScoredQueryFailed(placesResponse, nameof(SearchPlaces) + ".container", place);
+        if (placesResponse.Documents.Count == 0)
+        {
+            placesResponse = await _elasticClient.SearchAsync<BBoxDocument>(s => s.Index(BBOX)
+                .Size(1)
+                .TrackScores()
+                .Sort(f => f.Descending("_score"))
+                .Query(q => DocumentNameSearchQuery(q, place))
+            );
+            LogIfScoredQueryFailed(placesResponse, nameof(SearchPlaces) + ".containerFallback", place);
+        }
         if (placesResponse.Documents.Count == 0)
         {
             return [];
@@ -240,7 +495,7 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
             .Size(NUMBER_OF_RESULTS)
             .TrackScores()
             .Sort(f => f.Descending("_score"))
-            .Query(q => DocumentNameSearchQuery(q, searchTerm) &&
+            .Query(q => NameSearchWithScoring(q, searchTerm, lat, lng, zoom, prefix) &&
                 q.GeoShape(b =>
                 {
                     b.Field(p => p.Location);
@@ -260,7 +515,8 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
                 })
             )
         );
-        return response.Hits.Select(d => HitToFeature(d, language)).ToList();
+        LogIfScoredQueryFailed(response, nameof(SearchPlaces), searchTerm);
+        return HitsToFeatures(response, language);
     }
 
     public async Task<string> GetContainerName(Coordinate[] coordinates, string language)
@@ -333,5 +589,32 @@ public class ElasticSearchGateway(IOptions<ConfigurationData> options, ILogger l
                              != UnicodeCategory.NonSpacingMark)
         ).Normalize(NormalizationForm.FormC)
          .ToLowerInvariant();
+    }
+
+    private const string HebrewVav = "\u05D5";
+    private const string HebrewYod = "\u05D9";
+
+    private static string ApplyHebrewMatresDoubledOnly(string input)
+    {
+        if (string.IsNullOrEmpty(input)) return input;
+        return input
+            .Replace("\u05D5\u05D5", HebrewVav)
+            .Replace("\u05D9\u05D9", HebrewYod);
+    }
+
+    internal static string NormalizeForKeyword(string input, bool isHebrew)
+    {
+        if (string.IsNullOrEmpty(input)) return input;
+        if (!isHebrew)
+        {
+            return NormalizeSearchTerm(input);
+        }
+        var niqqudStripped = string.Concat(
+            input.Normalize(NormalizationForm.FormD)
+                 .Where(c => c < '\u05B0' || c > '\u05C7')
+                 .Where(c => CharUnicodeInfo.GetUnicodeCategory(c)
+                             != UnicodeCategory.NonSpacingMark)
+        ).Normalize(NormalizationForm.FormC);
+        return ApplyHebrewMatresDoubledOnly(niqqudStripped).ToLowerInvariant();
     }
 }

--- a/IsraelHiking.DataAccess/ElasticSearch/PointDocument.cs
+++ b/IsraelHiking.DataAccess/ElasticSearch/PointDocument.cs
@@ -5,10 +5,14 @@ public class PointDocument
 {
     [JsonPropertyName("name")]
     public Dictionary<string, string> Name { get; set; }
+    [JsonPropertyName("alt_names")]
+    public Dictionary<string, List<string>> AltNames { get; set; }
     [JsonPropertyName("description")]
     public Dictionary<string, string> Description { get; set; }
     [JsonPropertyName("poiCategory")]
     public string PoiCategory { get; set; }
+    [JsonPropertyName("poiFeatureClass")]
+    public string FeatureClass { get; set; }
     [JsonPropertyName("poiIcon")]
     public string PoiIcon { get; set; }
     [JsonPropertyName("poiIconColor")]
@@ -19,4 +23,6 @@ public class PointDocument
     public string Image { get; set; }
     [JsonPropertyName("location")]
     public double[] Location { get; set; }
+    [JsonPropertyName("poiProminence")]
+    public float? Prominence { get; set; }
 }

--- a/IsraelHiking.DataAccess/ElasticSearch/SearchLanguageDetector.cs
+++ b/IsraelHiking.DataAccess/ElasticSearch/SearchLanguageDetector.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using IsraelHiking.Common;
+
+namespace IsraelHiking.DataAccess.ElasticSearch;
+
+internal static class SearchLanguageDetector
+{
+    internal static string LanguageQueryName(string language) => "lang:" + language;
+
+    internal static string GetBestMatchLanguage(IReadOnlyCollection<string> matchedQueries, string fallbackLanguage)
+    {
+        if (matchedQueries == null || matchedQueries.Count == 0)
+        {
+            return fallbackLanguage;
+        }
+        foreach (var l in Languages.ArrayWithDefault)
+        {
+            if (matchedQueries.Contains(LanguageQueryName(l)))
+            {
+                return l;
+            }
+        }
+        return fallbackLanguage;
+    }
+}

--- a/IsraelHiking.DataAccess/IsraelHiking.DataAccess.csproj
+++ b/IsraelHiking.DataAccess/IsraelHiking.DataAccess.csproj
@@ -33,4 +33,8 @@
     <ProjectReference Include="..\IsraelHiking.Common\IsraelHiking.Common.csproj" />
     <ProjectReference Include="..\IsraelHiking.DataAccessInterfaces\IsraelHiking.DataAccessInterfaces.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="IsraelHiking.DataAccess.Tests" />
+  </ItemGroup>
 </Project>

--- a/IsraelHiking.DataAccessInterfaces/Repositories/ISearchRepository.cs
+++ b/IsraelHiking.DataAccessInterfaces/Repositories/ISearchRepository.cs
@@ -7,8 +7,10 @@ namespace IsraelHiking.DataAccessInterfaces.Repositories;
 
 public interface ISearchRepository
 {
-    Task<List<IFeature>> Search(string searchTerm, string language);
-    Task<List<IFeature>> SearchPlaces(string searchTerm, string language);
+    Task<List<IFeature>> Search(string searchTerm, string language,
+        double? lat = null, double? lng = null, double? zoom = null, bool prefix = false);
+    Task<List<IFeature>> SearchPlaces(string searchTerm, string language,
+        double? lat = null, double? lng = null, double? zoom = null, bool prefix = false);
     Task<List<IFeature>> SearchExact(string searchTerm, string language);
     Task<string> GetContainerName(Coordinate[] coordinates, string language);
 }

--- a/IsraelHiking.Web/Program.cs
+++ b/IsraelHiking.Web/Program.cs
@@ -121,6 +121,7 @@ void SetupServices(IServiceCollection services, bool isDevelopment)
 
     var config = new ConfigurationBuilder()
         .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+        .AddEnvironmentVariables()
         .Build();
     services.Configure<ConfigurationData>(config);
     var nonPublicConfiguration = new ConfigurationBuilder();

--- a/Tests/IsraelHiking.API.Tests/Controllers/SearchControllerTests.cs
+++ b/Tests/IsraelHiking.API.Tests/Controllers/SearchControllerTests.cs
@@ -270,4 +270,31 @@ public class SearchControllerTests
         Assert.IsNotNull(results);
         Assert.IsTrue(results.First().DisplayName.Contains(place));
     }
+
+    [TestMethod]
+    public void GetSearchResults_WithMapCenterAndPrefix_ShouldForwardThemToTheRepository()
+    {
+        var searchTerm = "Bear Lake";
+        _searchRepository.Search(searchTerm, Languages.ENGLISH,
+            Arg.Any<double?>(), Arg.Any<double?>(), Arg.Any<double?>(), Arg.Any<bool>())
+            .Returns(new List<IFeature>());
+
+        _controller.GetSearchResults(searchTerm, Languages.ENGLISH,
+            lat: 40.3120, lng: -105.6457, zoom: 12, prefix: true).Wait();
+
+        _searchRepository.Received(1).Search(searchTerm, Languages.ENGLISH, 40.3120, -105.6457, 12, true);
+    }
+
+    [TestMethod]
+    public void GetSearchResults_WithoutMapCenter_ShouldForwardDefaults()
+    {
+        var searchTerm = "Pikes Peak";
+        _searchRepository.Search(searchTerm, Languages.ENGLISH,
+            Arg.Any<double?>(), Arg.Any<double?>(), Arg.Any<double?>(), Arg.Any<bool>())
+            .Returns(new List<IFeature>());
+
+        _controller.GetSearchResults(searchTerm, Languages.ENGLISH).Wait();
+
+        _searchRepository.Received(1).Search(searchTerm, Languages.ENGLISH, null, null, null, false);
+    }
 }

--- a/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/GeoDecayParamsTests.cs
+++ b/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/GeoDecayParamsTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using IsraelHiking.DataAccess.ElasticSearch;
+
+namespace IsraelHiking.DataAccess.Tests.ElasticSearch;
+
+[TestClass]
+public class GeoDecayParamsTests
+{
+    [TestMethod]
+    public void ComputeGeoDecayParams_ZoomZero_FallsBackToDefaultZoomNotATinyRadius()
+    {
+        var atZero = ElasticSearchGateway.ComputeGeoDecayParams(0);
+        var atDefault = ElasticSearchGateway.ComputeGeoDecayParams(12);
+
+        Assert.AreEqual(atDefault.scaleKm, atZero.scaleKm, 1e-9,
+            "zoom=0 (no usable zoom) must fall back to DEFAULT_ZOOM, not a literal world view");
+        Assert.AreEqual(atDefault.offsetKm, atZero.offsetKm, 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeGeoDecayParams_NegativeZoom_AlsoFallsBack()
+    {
+        var atNegative = ElasticSearchGateway.ComputeGeoDecayParams(-3);
+        var atDefault = ElasticSearchGateway.ComputeGeoDecayParams(12);
+
+        Assert.AreEqual(atDefault.scaleKm, atNegative.scaleKm, 1e-9);
+        Assert.AreEqual(atDefault.offsetKm, atNegative.offsetKm, 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeGeoDecayParams_NullZoom_FallsBackToDefaultZoom()
+    {
+        var atNull = ElasticSearchGateway.ComputeGeoDecayParams(null);
+        var atDefault = ElasticSearchGateway.ComputeGeoDecayParams(12);
+
+        Assert.AreEqual(atDefault.scaleKm, atNull.scaleKm, 1e-9,
+            "an absent zoom must fall back to DEFAULT_ZOOM");
+        Assert.AreEqual(atDefault.offsetKm, atNull.offsetKm, 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeGeoDecayParams_NaNZoom_FallsBackInsteadOfPoisoningTheMath()
+    {
+        var atNaN = ElasticSearchGateway.ComputeGeoDecayParams(double.NaN);
+        var atDefault = ElasticSearchGateway.ComputeGeoDecayParams(12);
+
+        Assert.AreEqual(atDefault.scaleKm, atNaN.scaleKm, 1e-9,
+            "NaN <= 0 is false, so NaN must be rejected explicitly or it propagates through the decay math");
+        Assert.AreEqual(atDefault.offsetKm, atNaN.offsetKm, 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeGeoDecayParams_InfiniteZoom_IsCappedAtMaxZoom()
+    {
+        var atInfinity = ElasticSearchGateway.ComputeGeoDecayParams(double.PositiveInfinity);
+        var atMax = ElasticSearchGateway.ComputeGeoDecayParams(22);
+
+        Assert.AreEqual(atMax.scaleKm, atInfinity.scaleKm, 1e-9);
+        Assert.AreEqual(atMax.offsetKm, atInfinity.offsetKm, 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeGeoDecayParams_ImplausiblyDeepZoom_IsCappedAtMaxZoom()
+    {
+        var beyondMax = ElasticSearchGateway.ComputeGeoDecayParams(30);
+        var atMax = ElasticSearchGateway.ComputeGeoDecayParams(22);
+
+        Assert.AreEqual(atMax.scaleKm, beyondMax.scaleKm, 1e-9,
+            "a zoom past MAX_ZOOM must clamp, not grow the decay radius without bound");
+        Assert.AreEqual(atMax.offsetKm, beyondMax.offsetKm, 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeGeoDecayParams_RealZoom_TightensRadiusAsZoomIncreases()
+    {
+        var cityZoom = ElasticSearchGateway.ComputeGeoDecayParams(14);
+        var regionZoom = ElasticSearchGateway.ComputeGeoDecayParams(8);
+
+        Assert.IsTrue(cityZoom.offsetKm < regionZoom.offsetKm,
+            "a more zoomed-in view should have a smaller full-score plateau");
+    }
+}

--- a/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/LanguageDetectionExplainFreeGuardTests.cs
+++ b/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/LanguageDetectionExplainFreeGuardTests.cs
@@ -1,0 +1,90 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IsraelHiking.DataAccess.Tests.ElasticSearch;
+
+[TestClass]
+public class LanguageDetectionExplainFreeGuardTests
+{
+    private static string GatewaySourcePath([CallerFilePath] string thisFilePath = "")
+    {
+        var testDir = Path.GetDirectoryName(thisFilePath)!;
+        var siteRoot = Path.GetFullPath(Path.Combine(testDir, "..", "..", ".."));
+        return Path.Combine(siteRoot,
+            "IsraelHiking.DataAccess", "ElasticSearch", "ElasticSearchGateway.cs");
+    }
+
+    private static string ReadGatewaySource()
+    {
+        var path = GatewaySourcePath();
+        if (!File.Exists(path))
+        {
+            Assert.Inconclusive(
+                $"Gateway source not found at {path} — the test assembly is running without the " +
+                "source tree, so the source-shape guard is skipped.");
+        }
+        return File.ReadAllText(path);
+    }
+
+    private static string StripCommentsAndLiterals(string source)
+    {
+        var noBlock = Regex.Replace(source, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        var noVerbatim = Regex.Replace(noBlock, "@\"(?:[^\"]|\"\")*\"", "\"\"");
+        var noStrings = Regex.Replace(noVerbatim, "\"(?:\\\\.|[^\"\\\\])*\"", "\"\"");
+        var noChars = Regex.Replace(noStrings, @"'(?:\\.|[^'\\])'", "' '");
+        var noLine = Regex.Replace(noChars, @"//[^\n]*", " ");
+        return noLine;
+    }
+
+    [TestMethod]
+    public void Gateway_HasNoExplainBasedLanguageDetection()
+    {
+        var code = StripCommentsAndLiterals(ReadGatewaySource());
+
+        var forbidden = Regex.Match(code, @"\.Explain\s*\(");
+
+        Assert.IsFalse(forbidden.Success,
+            "ElasticSearchGateway has a '.Explain(' call. Language detection must use named queries " +
+            "(MatchedQueries), not the Lucene explain tree.");
+    }
+
+    [TestMethod]
+    public void Gateway_StillNamesPerLanguageClauses()
+    {
+        var code = StripCommentsAndLiterals(ReadGatewaySource());
+
+        Assert.IsTrue(Regex.IsMatch(code, @"\.Name\s*\(\s*(SearchLanguageDetector\s*\.\s*)?LanguageQueryName\("),
+            "ElasticSearchGateway no longer names the per-language phrase clauses with " +
+            "LanguageQueryName(...). MatchedQueries-based detection needs those names .");
+    }
+
+    private static bool HasLiveExplain(string code) =>
+        Regex.IsMatch(StripCommentsAndLiterals(code), @"\.Explain\s*\(");
+
+    [TestMethod]
+    public void Stripper_IgnoresExplainInDocComments()
+    {
+        Assert.IsFalse(HasLiveExplain("/// It uses the explanation object.\n var x = 1;"));
+        Assert.IsFalse(HasLiveExplain("/* parses the .Explain( tree */ var x = 1;"));
+    }
+
+    [TestMethod]
+    public void Stripper_IgnoresExplainInsideStringLiterals()
+    {
+        Assert.IsFalse(HasLiveExplain("var s = \".Explain(\"; var y = 2;"));
+    }
+
+    [TestMethod]
+    public void Stripper_StillCatchesLiveExplainAfterAUrlLiteral()
+    {
+        Assert.IsTrue(HasLiveExplain("var u = \"http://es:9200\"; resp = client.Search(s => s.Explain());"));
+    }
+
+    [TestMethod]
+    public void Stripper_CatchesAPlainLiveExplainCall()
+    {
+        Assert.IsTrue(HasLiveExplain("resp = client.Search(s => s.Index(\"x\").Explain());"));
+    }
+}

--- a/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/MapCenterValidationTests.cs
+++ b/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/MapCenterValidationTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using IsraelHiking.DataAccess.ElasticSearch;
+
+namespace IsraelHiking.DataAccess.Tests.ElasticSearch;
+
+[TestClass]
+public class MapCenterValidationTests
+{
+    [TestMethod]
+    public void ResolveMapCenter_BothCoordinatesInRange_IsUsed()
+    {
+        var center = ElasticSearchGateway.ResolveMapCenter(40.3120, -105.6457);
+
+        Assert.IsTrue(center.HasValue);
+        Assert.AreEqual(40.3120, center.Value.lat, 1e-9);
+        Assert.AreEqual(-105.6457, center.Value.lng, 1e-9);
+    }
+
+    [TestMethod]
+    public void ResolveMapCenter_NoCoordinates_IsAbsent()
+    {
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(null, null).HasValue);
+    }
+
+    [TestMethod]
+    public void ResolveMapCenter_HalfSuppliedCenter_IsRejectedRatherThanPartiallyForwarded()
+    {
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(40.3120, null).HasValue,
+            "a lat without a lon must not reach the script as a partial center");
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(null, -105.6457).HasValue);
+    }
+
+    [TestMethod]
+    public void ResolveMapCenter_NaNOrInfinite_IsRejected()
+    {
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(double.NaN, -105.6457).HasValue,
+            "NaN must be rejected explicitly or it propagates through Math.Cos into the viewport box");
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(40.3120, double.NaN).HasValue);
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(double.PositiveInfinity, 0).HasValue);
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(0, double.NegativeInfinity).HasValue);
+    }
+
+    [TestMethod]
+    public void ResolveMapCenter_OutOfRangeCoordinates_AreRejected()
+    {
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(95, 0).HasValue);
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(-95, 0).HasValue);
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(0, 181).HasValue);
+        Assert.IsFalse(ElasticSearchGateway.ResolveMapCenter(0, -181).HasValue);
+    }
+
+    [TestMethod]
+    public void ResolveMapCenter_CoordinateExtremes_AreAccepted()
+    {
+        Assert.IsTrue(ElasticSearchGateway.ResolveMapCenter(90, 180).HasValue);
+        Assert.IsTrue(ElasticSearchGateway.ResolveMapCenter(-90, -180).HasValue);
+        Assert.IsTrue(ElasticSearchGateway.ResolveMapCenter(0, 0).HasValue,
+            "null island is a valid center; only absent coordinates are not");
+    }
+}

--- a/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/NormalizeForKeywordTests.cs
+++ b/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/NormalizeForKeywordTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using IsraelHiking.DataAccess.ElasticSearch;
+
+namespace IsraelHiking.DataAccess.Tests.ElasticSearch;
+
+[TestClass]
+public class NormalizeForKeywordTests
+{
+
+    [TestMethod]
+    public void Base_FoldsLatinAccentsAndLowercases()
+    {
+        Assert.AreEqual("cafe", ElasticSearchGateway.NormalizeForKeyword("Café", isHebrew: false));
+    }
+
+    [TestMethod]
+    public void Base_LowercasesAsciiName()
+    {
+        Assert.AreEqual("eagle spring", ElasticSearchGateway.NormalizeForKeyword("Eagle Spring", isHebrew: false));
+    }
+
+    [TestMethod]
+    public void Base_DoesNotFoldHebrewMatres()
+    {
+        Assert.AreEqual("דוויד", ElasticSearchGateway.NormalizeForKeyword("דוויד", isHebrew: false));
+    }
+
+    [TestMethod]
+    public void He_CollapsesDoubledVav()
+    {
+        Assert.AreEqual("דויד", ElasticSearchGateway.NormalizeForKeyword("דוויד", isHebrew: true));
+    }
+
+    [TestMethod]
+    public void He_CollapsesDoubledYod()
+    {
+        Assert.AreEqual("איל", ElasticSearchGateway.NormalizeForKeyword("אייל", isHebrew: true));
+    }
+
+    [TestMethod]
+    public void He_LeavesSingleInteriorVavAndYodIntact()
+    {
+        Assert.AreEqual("אור", ElasticSearchGateway.NormalizeForKeyword("אור", isHebrew: true));
+        Assert.AreEqual("דוד", ElasticSearchGateway.NormalizeForKeyword("דוד", isHebrew: true));
+    }
+
+    [TestMethod]
+    public void He_StripsNiqqud()
+    {
+        Assert.AreEqual("שלום", ElasticSearchGateway.NormalizeForKeyword("שָׁלוֹם", isHebrew: true));
+    }
+
+    [TestMethod]
+    public void He_FoldsDoubledYodInIsraelBikeTrail()
+    {
+        Assert.AreEqual("שביל ישראל לאופנים",
+            ElasticSearchGateway.NormalizeForKeyword("שביל ישראל לאופניים", isHebrew: true));
+        Assert.AreEqual("שביל ישראל לאופניים",
+            ElasticSearchGateway.NormalizeForKeyword("שביל ישראל לאופניים", isHebrew: false));
+    }
+
+    [TestMethod]
+    public void He_NiqqudThenMatres_OrderIsCorrect()
+    {
+        Assert.AreEqual("ו", ElasticSearchGateway.NormalizeForKeyword("וֹו", isHebrew: true));
+    }
+
+}

--- a/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/SearchLanguageDetectorTests.cs
+++ b/Tests/IsraelHiking.DataAccess.Tests/ElasticSearch/SearchLanguageDetectorTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using IsraelHiking.Common;
+using IsraelHiking.DataAccess.ElasticSearch;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IsraelHiking.DataAccess.Tests.ElasticSearch;
+
+[TestClass]
+public class SearchLanguageDetectorTests
+{
+    [TestMethod]
+    public void GetBestMatchLanguage_SingleLanguageMatched_ReturnsThatLanguage()
+    {
+        var matched = new List<string> { SearchLanguageDetector.LanguageQueryName(Languages.RUSSIAN) };
+
+        var result = SearchLanguageDetector.GetBestMatchLanguage(matched, Languages.ENGLISH);
+
+        Assert.AreEqual(Languages.RUSSIAN, result);
+    }
+
+    [TestMethod]
+    public void GetBestMatchLanguage_MultipleMatched_PrefersDefaultPriorityOrder()
+    {
+        var matched = new List<string>
+        {
+            SearchLanguageDetector.LanguageQueryName(Languages.ENGLISH),
+            SearchLanguageDetector.LanguageQueryName(Languages.RUSSIAN)
+        };
+
+        var result = SearchLanguageDetector.GetBestMatchLanguage(matched, Languages.RUSSIAN);
+
+        Assert.AreEqual(Languages.ENGLISH, result);
+    }
+
+    [TestMethod]
+    public void GetBestMatchLanguage_EmptyMatchedQueries_ReturnsFallback()
+    {
+        var result = SearchLanguageDetector.GetBestMatchLanguage(new List<string>(), Languages.HEBREW);
+
+        Assert.AreEqual(Languages.HEBREW, result);
+    }
+
+    [TestMethod]
+    public void GetBestMatchLanguage_NullMatchedQueries_ReturnsFallback()
+    {
+        var result = SearchLanguageDetector.GetBestMatchLanguage(null, Languages.HEBREW);
+
+        Assert.AreEqual(Languages.HEBREW, result);
+    }
+
+    [TestMethod]
+    public void GetBestMatchLanguage_NoLanguageClauseMatched_ReturnsFallback()
+    {
+        var matched = new List<string> { "some-other-named-query" };
+
+        var result = SearchLanguageDetector.GetBestMatchLanguage(matched, Languages.ENGLISH);
+
+        Assert.AreEqual(Languages.ENGLISH, result);
+    }
+
+    [TestMethod]
+    public void LanguageQueryName_ProducesLangPrefixedName()
+    {
+        Assert.AreEqual("lang:en", SearchLanguageDetector.LanguageQueryName("en"));
+        Assert.AreEqual("lang:ru", SearchLanguageDetector.LanguageQueryName("ru"));
+    }
+}


### PR DESCRIPTION
## What & why

`Search()` currently ranks on text `_score` only. This adds a query-time `function_score` combining text + proximity + prominence + feature class, so a match near the map center and a more prominent feature of the same name rank higher.

**Query-side only — no reindex, no ES mapping change.** All new behavior is gated on optional inputs and degrades gracefully when the new index fields are absent.

## Scope

14 files, +837 / −117 (production: 8 files, +440 / −116; tests: 6 files, +397).

| Area | What |
|------|------|
| Scoring | `ElasticSearchGateway.cs`: `function_score` (`ScoreMode.Sum` / `BoostMode.Replace`) with a saturated text term, zoom-aware Gaussian geo decay (radius and plateau tighten as the user zooms in), a `field_value_factor` on `poiProminence`, a viewport bounding-box boost, and a bounded exact-name bonus granted once per document regardless of how many language subfields carry the name. |
| Query tiers | Exact-keyword, prefix (edge-ngram `name.<l>.prefix` with `match_phrase_prefix` as a `dis_max` sibling so autocomplete works before the new subfield exists), per-language `dis_max` match with named clauses for language detection, `alt_names` tiers at strictly lower boosts, fuzzy only for completed terms. Existing quote (exact) and comma (search-within-container) operators preserved. |
| Exact search | `SearchExact` keeps language detection via named per-language clauses, breaks same-score ties by `poiProminence` (`UnmappedType` keeps it valid on the current index), and logs query failures like the other paths. |
| API | `SearchController.cs`: optional `lat` / `lng` / `zoom` / `prefix` query params, all defaulting to absent. |
| Language detection | New `SearchLanguageDetector`: matched language recovered from named queries (`hit.MatchedQueries`) instead of the Lucene explain tree, which a `function_score` wrapper reshapes. |
| Autocomplete | Type-specific dropdown icons from `poiFeatureClass` when present in `_source`. |
| Build | `Program.cs` adds `AddEnvironmentVariables()` so `ElasticsearchServerAddress` can be overridden in a container. |
| Tests | Controller param-flow, language detection, keyword normalizer parity, geo-decay params, map-center validation, and a source guard against reintroducing explain-tree detection. |

## Non-breaking

- **Optional params.** `lat`/`lng`/`zoom`/`prefix` default to absent; with them absent, no geo functions are added and ranking changes only in how text tiers are weighted. Only the single `ISearchRepository` implementer changes signature.
- **Response shape unchanged.**
- **Safe on the current index.** Every new-field access is guarded or has a safe default: `poiProminence` uses `Missing(0)` and `UnmappedType` for the sort, unmapped `name.<l>.prefix` / `alt_names` tiers are a silent no-op in ES 7.17 with a mapped fallback tier, and query failures are logged instead of silently returning empty. The code degrades to text+proximity ranking until the index gains the new fields.

## Companion planet-search PR — Hebrew note

The index-side half is **[IsraelHikingMap/planet-search#63](https://github.com/IsraelHikingMap/planet-search/pull/63)** — it produces the build-time fields this query reads (`poiProminence`, `poiFeatureClass`, `alt_names`, `name.<l>.prefix`). That PR's mapping is additive **except for Hebrew**: `name.he` / `alt_names.he` move to a `hebrew_analyzer` with a doubled-matres fold (`וו→ו`, `יי→י`). After reindex, Hebrew searches match spelling variants they previously missed — an intentional, requested recall improvement, not a regression. This PR's `NormalizeForKeyword` mirrors that per-field normalization, so exact-name matching stays correct.

## How to review

- Start with `DocumentNameSearchQuery` (the query tiers) and `BuildScoreFunctions` (the score blend) in `ElasticSearchGateway.cs`.
- Key design calls: `dis_max` over per-language fields so a redundant language subfield can't inflate score; geo decay tied to zoom via `ComputeGeoDecayParams` (unit-tested); a single exact-name bonus that survives text-score saturation. Happy to expand the rationale on any specific choice.

## Merge order — this PR first

Merge this (Site) PR before the index PR **[planet-search#63](https://github.com/IsraelHikingMap/planet-search/pull/63)**. This is a binary redeploy with instant rollback and is safe on today's index; the index PR is a multi-hour reindex whose new fields do nothing until this is deployed. Landing the cheap, reversible half first lets you verify ranking on live traffic before committing to a reindex.

Deploy:
1. Rebuild and redeploy the Site binary; restart Site only, do not run the indexer. ES is untouched — Site is a read-only query client.
2. Rollback = redeploy the previous image.
3. Once verified live, merge `planet-search`; its fields light up on the next reindex and the already-deployed scoring uses them automatically.

## Follow-ups (not in this PR)

- The new index fields (separate PR [planet-search#63](https://github.com/IsraelHikingMap/planet-search/pull/63)).
- Relevance weight tuning (`WEIGHT_TEXT` / `WEIGHT_GEO` / `WEIGHT_PROMINENCE`) against live-traffic feedback — the current blend deliberately lets proximity outrank weak text matches.

