### PR TITLE
Improve offline management screen

### DIFF
--- a/IsraelHiking.Web/src/application/components/main-menu.component.ts
+++ b/IsraelHiking.Web/src/application/components/main-menu.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, inject, computed, signal, afterNextRender } from "@angular/core";
+import { Component, inject, computed, signal, afterNextRender } from "@angular/core";
 import { RouterLink, RouterLinkActive } from "@angular/router";
 import { MatButton } from "@angular/material/button";
 import { MatMenuTrigger, MatMenu, MatMenuItem } from "@angular/material/menu";

--- a/IsraelHiking.Web/src/application/components/main-menu.component.ts
+++ b/IsraelHiking.Web/src/application/components/main-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, computed, signal, afterNextRender } from "@angular/core";
+﻿import { Component, inject, computed, signal, afterNextRender } from "@angular/core";
 import { RouterLink, RouterLinkActive } from "@angular/router";
 import { MatButton } from "@angular/material/button";
 import { MatMenuTrigger, MatMenu, MatMenuItem } from "@angular/material/menu";
@@ -134,7 +134,7 @@ export class MainMenuComponent {
                 return;
             }
             const info = await Device.getInfo();
-            const downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.offlineState.downloadedTiles);
+            const downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
             infoString += [
                 `Manufacture: ${info.manufacturer}`,
                 `Model: ${info.model}`,
@@ -142,7 +142,7 @@ export class MainMenuComponent {
                 `OS version: ${info.osVersion}`,
                 `App version: ${(await App.getInfo()).version}`,
                 `Has Subscription: ${this.store.selectSnapshot((s: ApplicationState) => s.offlineState.isSubscribed)}`,
-                downloadedTiles == null ? "" : `Downloaded Tiles: ${Object.keys(downloadedTiles)}`
+                `Downloaded Tiles: ${Object.keys(downloadedTiles)}`
             ].join("\n");
             const logFileUri = await this.fileService.storeFileToCache("log.txt", logs, false);
             const infoBase64 = encode(await new Response(infoString).arrayBuffer());

--- a/IsraelHiking.Web/src/application/components/map/automatic-layer-presentation.component.ts
+++ b/IsraelHiking.Web/src/application/components/map/automatic-layer-presentation.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit, OnChanges, SimpleChanges, OnDestroy, OutputRefSubscription, inject, input } from "@angular/core";
+import { Component, OnInit, OnChanges, SimpleChanges, OnDestroy, OutputRefSubscription, inject, input } from "@angular/core";
 import { MapComponent } from "@maplibre/ngx-maplibre-gl";
 import { Subject, mergeMap } from "rxjs";
 import { Store } from "@ngxs/store";

--- a/IsraelHiking.Web/src/application/components/map/automatic-layer-presentation.component.ts
+++ b/IsraelHiking.Web/src/application/components/map/automatic-layer-presentation.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnChanges, SimpleChanges, OnDestroy, OutputRefSubscription, inject, input } from "@angular/core";
+﻿import { Component, OnInit, OnChanges, SimpleChanges, OnDestroy, OutputRefSubscription, inject, input } from "@angular/core";
 import { MapComponent } from "@maplibre/ngx-maplibre-gl";
 import { Subject, mergeMap } from "rxjs";
 import { Store } from "@ngxs/store";
@@ -48,7 +48,7 @@ export class AutomaticLayerPresentationComponent implements OnInit, OnChanges, O
             }
             this.currentLanguageCode = language.code;
         }));
-        this.subscriptions.push(this.store.select((state: ApplicationState) => state.offlineState.downloadedTiles).subscribe(() => {
+        this.subscriptions.push(this.store.select((state: ApplicationState) => state.inMemoryState.downloadedTiles).subscribe(() => {
             this.addLayerRecreationQuqueItem(this.layerData(), this.layerData());
         }));
         this.subscriptions.push(this.store.select((state: ApplicationState) => state.configuration.units).subscribe(() => {

--- a/IsraelHiking.Web/src/application/components/screens/offline-management.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/offline-management.component.html
@@ -1,4 +1,4 @@
-<div class="w-full h-screen relative" [dir]="resources.direction">
+﻿<div class="w-full h-screen relative" [dir]="resources.direction">
     <mgl-map [mapStyle]="offlineMapStyle" (mapClick)="onMapClick($event)" (mapLoad)="onMapLoad($event)"
         [attributionControl]="false">
         <auto-layer [layerData]="baseLayerData" [visible]="true" [isBaselayer]="true" [allowOffline]="false"
@@ -8,18 +8,29 @@
         </mgl-geojson-source>
         <mgl-geojson-source id="currnet-location" [data]="currentLocation">
         </mgl-geojson-source>
-        <mgl-layer id="download-tiles-border" type="line" source="download-tiles" [layout]="{
-              'line-cap': 'round', 
+        <mgl-layer id="download-tiles-border" type="line" source="download-tiles"
+            [filter]="['!=', ['get', 'incompatible'], 'true']" [layout]="{
+              'line-cap': 'round',
               'line-join': 'round'
           }" [paint]="{
               'line-color': ['get', 'color'],
               'line-width': 3
           }">
         </mgl-layer>
+        <mgl-layer id="download-tiles-border-incompatible" type="line" source="download-tiles"
+            [filter]="['==', ['get', 'incompatible'], 'true']" [layout]="{
+              'line-cap': 'butt',
+              'line-join': 'round'
+          }" [paint]="{
+              'line-color': ['get', 'color'],
+              'line-width': 3,
+              'line-dasharray': [2, 1]
+          }">
+        </mgl-layer>
         <mgl-layer id="download-tiles-text" type="symbol" source="download-tiles" [minzoom]="4" [layout]="{
               'text-field': ['get', 'label'],
               'text-font': ['Noto Sans Regular'],
-              'text-size': 30,
+              'text-size': ['get', 'textSize'],
           }" [paint]="{
               'text-color': ['get', 'color'],
               'text-halo-color' : 'white',
@@ -82,16 +93,9 @@
         </mgl-layer>
     </mgl-map>
 </div>
-<div class="absolute bottom-safe w-full text-lg text-center">
+<div class="absolute bottom-safe w-full text-lg text-center" [dir]="resources.direction">
     <div class="flex flex-row">
-        @if (!selectedTileXY() && !downloadingTileXY()) {
-        <div class="flex-1 bg-surface">
-            <div class="p-2">
-                {{resources.clickTheMapToSelectATile}}
-            </div>
-        </div>
-        }
-        @if (selectedTileXY() && !isSelectedAvailableForOffline() && !downloadingTileXY()) {
+        @if (selectedTileXY() && !isSelectedAvailableForOffline() && !downloadingTile()) {
         <div class="flex-1 m-1">
             <button mat-flat-button class="w-full" (click)="downloadSelected()" analyticsOn="click"
                 analyticsCategory="Offline Management" analyticsLabel="Download">
@@ -100,12 +104,13 @@
             </button>
         </div>
         }
-        @if (selectedTileXY() && isSelectedAvailableForOffline() && !downloadingTileXY()) {
+        @if (selectedTileXY() && isSelectedAvailableForOffline() && !downloadingTile()) {
         <div class="flex-1 m-1">
             <button mat-flat-button class="w-full" (click)="downloadSelected()" analyticsOn="click"
-                analyticsCategory="Offline Management" analyticsLabel="Update">
+                analyticsCategory="Offline Management"
+                [analyticsLabel]="isSelectedIncompatible() ? 'Download Again' : 'Update'">
                 <i class="fa fa-lg icon-download"></i>
-                {{resources.update}}
+                {{isSelectedIncompatible() ? resources.download : resources.update}}
             </button>
         </div>
         <div class="flex-1 m-1">
@@ -116,7 +121,7 @@
             </button>
         </div>
         }
-        @if (downloadingTileXY()) {
+        @if (downloadingTile()) {
         <div class="flex-1 m-1">
             <button mat-flat-button class="w-full" (click)="cancelDownload()" analyticsOn="click"
                 analyticsCategory="Offline Management" analyticsLabel="Cancel">
@@ -126,4 +131,21 @@
         </div>
         }
     </div>
+    @if (statusMessage()) {
+    <div class="bg-surface p-2 flex flex-row items-center justify-center gap-2"
+        [class.text-warning]="isStatusWarning()">
+        @if (isStatusWarning()) {
+        <i class="fa fa-lg icon-exclamation-triangle"></i>
+        }
+        <span>{{statusMessage()}}</span>
+        @if (isStatusWarning()) {
+        <button mat-button (click)="selectNextIncompatible()" analyticsOn="click"
+            analyticsCategory="Offline Management" analyticsLabel="Next Incompatible">
+            <i class="fa fa-lg" [class.icon-chevron-left]="resources.direction === 'rtl'"
+                [class.icon-chevron-right]="resources.direction !== 'rtl'"></i>
+            {{resources.next}}
+        </button>
+        }
+    </div>
+    }
 </div>

--- a/IsraelHiking.Web/src/application/components/screens/offline-management.component.html
+++ b/IsraelHiking.Web/src/application/components/screens/offline-management.component.html
@@ -1,4 +1,4 @@
-﻿<div class="w-full h-screen relative" [dir]="resources.direction">
+<div class="w-full h-screen relative" [dir]="resources.direction">
     <mgl-map [mapStyle]="offlineMapStyle" (mapClick)="onMapClick($event)" (mapLoad)="onMapLoad($event)"
         [attributionControl]="false">
         <auto-layer [layerData]="baseLayerData" [visible]="true" [isBaselayer]="true" [allowOffline]="false"

--- a/IsraelHiking.Web/src/application/components/screens/offline-management.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/offline-management.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, inject, signal, computed } from "@angular/core";
+import { Component, inject, signal, computed } from "@angular/core";
 import { Store } from "@ngxs/store";
 import { GeoJSONSourceComponent, LayerComponent, MapComponent } from "@maplibre/ngx-maplibre-gl";
 import { type Map, type MapMouseEvent, MercatorCoordinate, type StyleSpecification } from "maplibre-gl";

--- a/IsraelHiking.Web/src/application/components/screens/offline-management.component.ts
+++ b/IsraelHiking.Web/src/application/components/screens/offline-management.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed } from "@angular/core";
+﻿import { Component, inject, signal, computed } from "@angular/core";
 import { Store } from "@ngxs/store";
 import { GeoJSONSourceComponent, LayerComponent, MapComponent } from "@maplibre/ngx-maplibre-gl";
 import { type Map, type MapMouseEvent, MercatorCoordinate, type StyleSpecification } from "maplibre-gl";
@@ -11,7 +11,7 @@ import { OfflineFilesDownloadService } from "../../services/offline-files-downlo
 import { DefaultStyleService } from "../../services/default-style.service";
 import { LayersService } from "../../services/layers.service";
 import { ToastService } from "../../services/toast.service";
-import { TILES_ZOOM } from "../../services/pmtiles.service";
+import { PmTilesService, TILES_ZOOM } from "../../services/pmtiles.service";
 import { SpatialService } from "../../services/spatial.service";
 import { DEFAULT_BASE_LAYERS, HIKING_MAP, MTB_MAP } from "../../reducers/initial-state";
 import type { ApplicationState, EditableLayer } from "../../models";
@@ -23,9 +23,6 @@ import type { ApplicationState, EditableLayer } from "../../models";
 })
 export class OfflineManagementComponent {
     public readonly offlineMapStyle: StyleSpecification;
-    public readonly selectedTile = signal<GeoJSON.FeatureCollection>({ features: [], type: "FeatureCollection" });
-    public readonly inProgressTile = signal<GeoJSON.FeatureCollection>({ features: [], type: "FeatureCollection" });
-    public readonly downloadedTiles = signal<GeoJSON.FeatureCollection>({ features: [], type: "FeatureCollection" });
     public readonly currentLocation: GeoJSON.FeatureCollection;
     public readonly baseLayerData: EditableLayer;
     public readonly selectedTileXY = signal<{ tileX: number; tileY: number }>(null);
@@ -37,15 +34,129 @@ export class OfflineManagementComponent {
     private readonly layersService = inject(LayersService);
     private readonly toastService = inject(ToastService);
     private readonly store = inject(Store);
-    private readonly downloadedTilesState = this.store.selectSignal((s: ApplicationState) => s.offlineState.downloadedTiles);
+    private readonly downloadedTilesState = this.store.selectSignal((s: ApplicationState) => s.inMemoryState.downloadedTiles);
     public readonly resources = inject(ResourcesService);
+
+    /** The tile that is being downloaded right now and how far it got, null when there is no download */
+    public readonly downloadingTile = this.offlineFilesDownloadService.currentDownloadedTile;
 
     public readonly isSelectedAvailableForOffline = computed(() => {
         if (!this.selectedTileXY()) {
             return false;
         }
         const downloadedTiles = this.downloadedTilesState();
-        return downloadedTiles != null && downloadedTiles[`${this.selectedTileXY().tileX}-${this.selectedTileXY().tileY}`] != null;
+        return downloadedTiles[PmTilesService.toTileKey(this.selectedTileXY().tileX, this.selectedTileXY().tileY)] != null;
+    });
+
+    /**
+     * The tiles that are on the device but can no longer be used, sorted so that moving to the next one
+     * keeps the same order every time. The root files are not of a specific tile, so they are not here -
+     * they are not drawn on the map either, and they are updated along with any tile that is downloaded.
+     */
+    public readonly incompatibleTileKeys = computed<string[]>(() => {
+        const downloadedTiles = this.downloadedTilesState();
+        return Object.keys(downloadedTiles)
+            .filter(tileKey => PmTilesService.fromTileKey(tileKey) != null)
+            .filter(tileKey => !this.offlineFilesDownloadService.isTileCompatible(tileKey, downloadedTiles[tileKey]))
+            .sort();
+    });
+
+    public readonly isSelectedIncompatible = computed(() => {
+        const selectedTileXY = this.selectedTileXY();
+        if (selectedTileXY == null) {
+            return false;
+        }
+        return this.incompatibleTileKeys().includes(PmTilesService.toTileKey(selectedTileXY.tileX, selectedTileXY.tileY));
+    });
+
+    /**
+     * What to tell the user below the buttons: how many tiles need to be downloaded again, falling back to
+     * explaining how a tile is selected. The count is kept while a tile is selected rather than being
+     * replaced by something about that tile, so that the user can see how many are left as they go over
+     * them. Nothing is said while a tile is being downloaded, the progress on the tile itself says it.
+     */
+    public readonly statusMessage = computed<string>(() => {
+        if (this.downloadingTile() != null) {
+            return null;
+        }
+        const incompatibleCount = this.incompatibleTileKeys().length;
+        if (incompatibleCount === 1) {
+            return this.resources.oneTileNeedsToBeDownloadedAgain;
+        }
+        if (incompatibleCount > 1) {
+            return this.resources.tilesNeedToBeDownloadedAgain.replace("{{count}}", incompatibleCount.toString());
+        }
+        return this.selectedTileXY() == null ? this.resources.clickTheMapToSelectATile : null;
+    });
+
+    /** Whether the message is about tiles that need to be downloaded again and not just an explanation */
+    public readonly isStatusWarning = computed(() =>
+        this.downloadingTile() == null && this.incompatibleTileKeys().length > 0);
+
+    /**
+     * The tiles that were downloaded, drawn from the files that are on the device - they are read into
+     * the state while the app is running, so this follows it instead of being built once.
+     * The tile that is being downloaded and the selected one are drawn on their own, so they are skipped.
+     * A tile that can no longer be used is marked with a "!" rather than with the date it was downloaded
+     * at, which is not the reason it can't be used, and is drawn with a dashed outline so that it is told
+     * apart from the rest without relying on its color alone.
+     */
+    public readonly downloadedTiles = computed<GeoJSON.FeatureCollection>(() => {
+        const features: GeoJSON.Feature[] = [];
+        const downloadedTiles = this.downloadedTilesState();
+        for (const tileKey of Object.keys(downloadedTiles)) {
+            const downloadedTile = PmTilesService.fromTileKey(tileKey);
+            if (downloadedTile == null) {
+                continue;
+            }
+            const { tileX: tileXDownloaded, tileY: tileYDownloaded } = downloadedTile;
+            if (this.downloadingTile()?.tileX === tileXDownloaded && this.downloadingTile()?.tileY === tileYDownloaded) {
+                continue; // Skip tiles that are in progress
+            }
+            const { tileX, tileY } = this.selectedTileXY() || { tileX: null, tileY: null };
+            if (this.downloadingTile() == null && tileXDownloaded === tileX && tileYDownloaded === tileY) {
+                continue; // Skip the center tile if not downloading
+            }
+
+            const isCompatible = this.offlineFilesDownloadService.isTileCompatible(tileKey, downloadedTiles[tileKey]);
+            let label = "!";
+            if (isCompatible) {
+                const downloadedDate = this.offlineFilesDownloadService.getLastModifiedDate(downloadedTiles[tileKey]);
+                label = downloadedDate.getFullYear() + "\n" +
+                    (downloadedDate.getMonth() + 1).toLocaleString(this.resources.getCurrentLanguageCodeSimplified(), { minimumIntegerDigits: 2 }) + "\n" +
+                    downloadedDate.getDate().toLocaleString(this.resources.getCurrentLanguageCodeSimplified(), { minimumIntegerDigits: 2 });
+            }
+            const feature = this.tileCoordinatesToPolygon(tileXDownloaded, tileYDownloaded, label, 1);
+            feature.properties.color = isCompatible ? "blue" : "#ef6c00";
+            feature.properties.incompatible = isCompatible ? "false" : "true";
+            feature.properties.textSize = isCompatible ? 30 : 60;
+            features.push(feature);
+        }
+
+        return { type: "FeatureCollection", features };
+    });
+
+    /** The tile the user selected, it is not drawn while a tile is being downloaded */
+    public readonly selectedTile = computed<GeoJSON.FeatureCollection>(() => {
+        const selectedTileXY = this.selectedTileXY();
+        const features = selectedTileXY == null || this.downloadingTile() != null
+            ? []
+            : [this.tileCoordinatesToPolygon(selectedTileXY.tileX, selectedTileXY.tileY, this.resources.clickBelow)];
+        return { type: "FeatureCollection", features };
+    });
+
+    /** The tile that is being downloaded, filled up to the progress of its download */
+    public readonly inProgressTile = computed<GeoJSON.FeatureCollection>(() => {
+        const downloadingTile = this.downloadingTile();
+        if (downloadingTile == null) {
+            return { type: "FeatureCollection", features: [] };
+        }
+        const { tileX, tileY, progress } = downloadingTile;
+        const fillFeature = this.tileCoordinatesToPolygon(tileX, tileY, "", progress / 100.0);
+        fillFeature.properties.fill = "true";
+        const strokeFeature = this.tileCoordinatesToPolygon(tileX, tileY, progress.toFixed(2) + "%");
+        strokeFeature.properties.stroke = "true";
+        return { type: "FeatureCollection", features: [fillFeature, strokeFeature] };
     });
 
     constructor() {
@@ -66,17 +177,11 @@ export class OfflineManagementComponent {
                 }
             }]
         }
-        this.updateDownloadedTiles();
-        this.offlineFilesDownloadService.tilesProgressChanged.subscribe((tileProgress) => {
-            if (this.downloadingTileXY()) {
-                this.updateInProgressTile(tileProgress.progressValue);
-            }
-        });
     }
 
     private initializeCenterAndZoomFromDownloadingTile() {
-        const dowloadedTiles = this.store.selectSnapshot((state: ApplicationState) => state.offlineState.downloadedTiles);
-        if (!dowloadedTiles) {
+        const dowloadedTiles = this.store.selectSnapshot((state: ApplicationState) => state.inMemoryState.downloadedTiles);
+        if (Object.keys(dowloadedTiles).length === 0) {
             const mapCenter = this.store.selectSnapshot((state: ApplicationState) => state.locationState);
             this.map.flyTo({
                 center: [mapCenter.longitude, mapCenter.latitude],
@@ -89,11 +194,12 @@ export class OfflineManagementComponent {
         let maxTileX = Number.MIN_SAFE_INTEGER;
         let minTileY = Number.MAX_SAFE_INTEGER;
         let maxTileY = Number.MIN_SAFE_INTEGER;
-        for (const key of Object.keys(dowloadedTiles)) {
-            const [tileX, tileY] = key.split("-").map(Number);
-            if (isNaN(tileX) || isNaN(tileY)) {
+        for (const toTileKey of Object.keys(dowloadedTiles)) {
+            const tile = PmTilesService.fromTileKey(toTileKey);
+            if (tile == null) {
                 continue;
             }
+            const { tileX, tileY } = tile;
             minTileX = Math.min(minTileX, tileX);
             maxTileX = Math.max(maxTileX, tileX);
             minTileY = Math.min(minTileY, tileY);
@@ -113,8 +219,6 @@ export class OfflineManagementComponent {
             zoom: TILES_ZOOM - 1
         });
         this.selectedTileXY.set(null);
-        this.updateDownloadedTiles();
-        this.updateSelectedTile();
         const status = await this.offlineFilesDownloadService.downloadTile(tileX, tileY);
         switch (status) {
             case "up-to-date":
@@ -131,14 +235,6 @@ export class OfflineManagementComponent {
                 this.selectedTileXY.set({ tileX, tileY });
                 break;
         }
-
-        // For some reason, sometime it gets to 100% and doesn't clear the download progress, this is a hack to prevent it...
-        setTimeout(() => {
-            this.updateInProgressTile(100);
-            this.updateDownloadedTiles();
-            this.updateSelectedTile();
-        }, 3000)
-
     }
 
 
@@ -163,74 +259,10 @@ export class OfflineManagementComponent {
         }
     }
 
-    private updateDownloadedTiles() {
-        const features: GeoJSON.Feature[] = [];
-        const downloadedTiles = this.store.selectSnapshot((state: ApplicationState) => state.offlineState.downloadedTiles);
-        for (const key of Object.keys(downloadedTiles || {})) {
-            const [tileXDownloaded, tileYDownloaded] = key.split("-").map(Number);
-            if (isNaN(tileXDownloaded) || isNaN(tileYDownloaded)) {
-                continue;
-            }
-            if (this.downloadingTileXY()?.tileX === tileXDownloaded && this.downloadingTileXY()?.tileY === tileYDownloaded) {
-                continue; // Skip tiles that are in progress
-            }
-            const { tileX, tileY } = this.selectedTileXY() || { tileX: null, tileY: null };
-            if (this.downloadingTileXY() == null && tileXDownloaded === tileX && tileYDownloaded === tileY) {
-                continue; // Skip the center tile if not downloading
-            }
 
-            const downloadedDate = this.offlineFilesDownloadService.getLastModifiedDate(downloadedTiles[key]);
-            const label = downloadedDate.getFullYear() + "\n" +
-                (downloadedDate.getMonth() + 1).toLocaleString(this.resources.getCurrentLanguageCodeSimplified(), { minimumIntegerDigits: 2 }) + "\n" +
-                downloadedDate.getDate().toLocaleString(this.resources.getCurrentLanguageCodeSimplified(), { minimumIntegerDigits: 2 });
-            const feature = this.tileCoordinatesToPolygon(tileXDownloaded, tileYDownloaded, label, 1);
-            feature.properties.color = this.offlineFilesDownloadService.isTileCompatible(downloadedTiles[key]) ? "blue" : "red";
-            features.push(feature);
-        }
-
-        this.downloadedTiles.set({
-            type: "FeatureCollection",
-            features: features
-        });
-    }
-
-    private updateSelectedTile() {
-        const { tileX, tileY } = this.selectedTileXY() || { tileX: null, tileY: null };
-        this.selectedTile.set({
-            type: "FeatureCollection",
-            features: this.downloadingTileXY() != null || this.selectedTileXY() == null ? [] : [this.tileCoordinatesToPolygon(tileX, tileY, this.resources.clickBelow)]
-        });
-    }
-
-    private updateInProgressTile(progress: number) {
-        if (this.downloadingTileXY() == null) {
-            this.inProgressTile.set({ type: "FeatureCollection", features: [] });
-            return;
-        }
-        const fillFeature = this.tileCoordinatesToPolygon(
-            this.downloadingTileXY().tileX,
-            this.downloadingTileXY().tileY,
-            "",
-            progress / 100.0
-        );
-        fillFeature.properties.fill = "true";
-        const strokeFeature = this.tileCoordinatesToPolygon(
-            this.downloadingTileXY().tileX,
-            this.downloadingTileXY().tileY,
-            progress.toFixed(2) + "%"
-        );
-        strokeFeature.properties.stroke = "true";
-        this.inProgressTile.set({
-            type: "FeatureCollection",
-            features: [fillFeature, strokeFeature]
-        });
-    }
 
     public cancelDownload() {
         this.offlineFilesDownloadService.abortCurrentDownload();
-        this.updateDownloadedTiles();
-        this.updateInProgressTile(100);
-        this.updateSelectedTile();
     }
 
     public onMapClick(event: MapMouseEvent) {
@@ -238,13 +270,34 @@ export class OfflineManagementComponent {
         const mercator = MercatorCoordinate.fromLngLat(event.lngLat);
         const tileX = Math.floor((mercator.x * tileCount));
         const tileY = Math.floor((mercator.y * tileCount));
+        this.selectTile(tileX, tileY);
+    }
+
+    private selectTile(tileX: number, tileY: number) {
         this.selectedTileXY.set({ tileX, tileY });
-        this.updateSelectedTile();
-        this.updateDownloadedTiles();
         this.map.flyTo({
             center: SpatialService.toCoordinate(SpatialService.fromTile({ x: tileX + 0.5, y: tileY + 0.5 }, TILES_ZOOM)),
             zoom: TILES_ZOOM - 1
         });
+    }
+
+    /**
+     * Moves to the tile that needs to be downloaded again after the one that is selected, so that the user
+     * can go over them one at a time and download each one when they want to. It goes back to the first one
+     * after the last, since a tile stays in the list until it is downloaded again or deleted.
+     */
+    public selectNextIncompatible() {
+        const incompatibleTileKeys = this.incompatibleTileKeys();
+        if (incompatibleTileKeys.length === 0) {
+            return;
+        }
+        const selectedTileXY = this.selectedTileXY();
+        const selectedTileKey = selectedTileXY == null
+            ? null
+            : PmTilesService.toTileKey(selectedTileXY.tileX, selectedTileXY.tileY);
+        const nextIndex = (incompatibleTileKeys.indexOf(selectedTileKey) + 1) % incompatibleTileKeys.length;
+        const { tileX, tileY } = PmTilesService.fromTileKey(incompatibleTileKeys[nextIndex]);
+        this.selectTile(tileX, tileY);
     }
 
     public onMapLoad(map: Map) {
@@ -262,15 +315,9 @@ export class OfflineManagementComponent {
             message: this.resources.areYouSure,
             type: "YesNo",
             confirmAction: async () => {
-                await this.offlineFilesDownloadService.deleteTile(this.selectedTileXY().tileX, this.selectedTileXY().tileY);
+                await this.offlineFilesDownloadService.deleteTile(PmTilesService.toTileKey(this.selectedTileXY().tileX, this.selectedTileXY().tileY));
                 this.selectedTileXY.set(null);
-                this.updateSelectedTile();
-                this.updateDownloadedTiles();
             }
         });
-    }
-
-    public downloadingTileXY() {
-        return this.offlineFilesDownloadService.currentDownloadedTile;
     }
 }

--- a/IsraelHiking.Web/src/application/models/index.d.ts
+++ b/IsraelHiking.Web/src/application/models/index.d.ts
@@ -36,7 +36,7 @@ export type { ShareUrlsState } from "./state/share-urls-state";
 export type { UserState } from "./state/user-state";
 export type { PointsOfInterestState } from "./state/poi-state";
 export type { InMemoryState } from "./state/in-memory-state";
-export type { OfflineState, TileMetadataPerFile, FileNameDateVersion } from "./state/offline-state";
+export type { OfflineState, FileNameDateVersion } from "./state/offline-state";
 export type { GpsState, TrackingStateType } from "./state/gps-state";
 export type { RouteEditingState } from "./state/route-editing-state";
 export type { RecordedRouteState } from "./state/recorded-route-state";

--- a/IsraelHiking.Web/src/application/models/state/in-memory-state.d.ts
+++ b/IsraelHiking.Web/src/application/models/state/in-memory-state.d.ts
@@ -14,11 +14,6 @@ export type InMemoryState = {
      * and empty until they were read, which is also what an empty device looks like.
      */
     downloadedTiles: Record<string, FileNameDateVersion[]>;
-    /**
-     * The ids of the tiles whose routing tiles are on the device. They are not files, the routing
-     * plugin stores them, so they are read from it when the app starts just like the files are.
-     */
-    downloadedRoutingTiles: string[];
     distance: boolean;
     pannedTimestamp: Date;
     following: boolean;

--- a/IsraelHiking.Web/src/application/models/state/in-memory-state.d.ts
+++ b/IsraelHiking.Web/src/application/models/state/in-memory-state.d.ts
@@ -1,4 +1,4 @@
-﻿import type { ShareUrl, PublicRoutesFilter, Theme } from "..";
+﻿import type { ShareUrl, PublicRoutesFilter, Theme, FileNameDateVersion } from "..";
 
 /**
  * this state should be clean every time the app starts
@@ -8,6 +8,17 @@ export type InMemoryState = {
      * The theme that is actually applied - the configured theme with "auto" already resolved to light or dark.
      */
     effectiveTheme: Theme;
+    /**
+     * The offline files that are on the device, keyed by the id of the tile they belong to.
+     * They are read from the device when the app starts, so they are never out of sync with it,
+     * and empty until they were read, which is also what an empty device looks like.
+     */
+    downloadedTiles: Record<string, FileNameDateVersion[]>;
+    /**
+     * The ids of the tiles whose routing tiles are on the device. They are not files, the routing
+     * plugin stores them, so they are read from it when the app starts just like the files are.
+     */
+    downloadedRoutingTiles: string[];
     distance: boolean;
     pannedTimestamp: Date;
     following: boolean;

--- a/IsraelHiking.Web/src/application/models/state/offline-state.d.ts
+++ b/IsraelHiking.Web/src/application/models/state/offline-state.d.ts
@@ -4,13 +4,7 @@
     version?: string;
 }
 
-export type TileMetadataPerFile = Date | FileNameDateVersion[];
-
 export type OfflineState = {
-    /**
-     * The downloaded tiles, key is the tile id and value is the date it was downloaded
-     */
-    downloadedTiles: Record<string, TileMetadataPerFile>;
     /**
      * `true` after a user made a purchase of the subscription 
      */

--- a/IsraelHiking.Web/src/application/reducers/in-memory.reducer.ts
+++ b/IsraelHiking.Web/src/application/reducers/in-memory.reducer.ts
@@ -1,9 +1,9 @@
-import { State, Action, StateContext } from "@ngxs/store";
+﻿import { State, Action, StateContext } from "@ngxs/store";
 import { Injectable } from "@angular/core";
 import { produce } from "immer";
 
 import { initialState } from "./initial-state";
-import type { ShareUrl, InMemoryState, PublicRoutesFilter, Theme } from "../models";
+import type { ShareUrl, InMemoryState, PublicRoutesFilter, Theme, FileNameDateVersion } from "../models";
 
 export class ToggleDistanceAction {
     public static readonly type = "[In Memory] ToggleDistanceAction";
@@ -51,6 +51,16 @@ export class SetPublicRoutesFilterAction {
 export class SetEffectiveThemeAction {
     public static readonly type = "[In Memory] SetEffectiveThemeAction";
     constructor(public readonly theme: Theme) { }
+}
+
+export class SetDownloadedTilesAction {
+    public static readonly type = "[In Memory] SetDownloadedTilesAction";
+    constructor(public readonly downloadedTiles: Record<string, FileNameDateVersion[]>) { }
+}
+
+export class SetDownloadedRoutingTilesAction {
+    public static readonly type = "[In Memory] SetDownloadedRoutingTilesAction";
+    constructor(public readonly downloadedRoutingTiles: string[]) { }
 }
 
 @State({
@@ -137,6 +147,22 @@ export class InMemoryReducer {
     public setEffectiveTheme(ctx: StateContext<InMemoryState>, action: SetEffectiveThemeAction) {
         ctx.setState(produce(ctx.getState(), lastState => {
             lastState.effectiveTheme = action.theme;
+            return lastState;
+        }));
+    }
+
+    @Action(SetDownloadedTilesAction)
+    public setDownloadedTiles(ctx: StateContext<InMemoryState>, action: SetDownloadedTilesAction) {
+        ctx.setState(produce(ctx.getState(), lastState => {
+            lastState.downloadedTiles = action.downloadedTiles;
+            return lastState;
+        }));
+    }
+
+    @Action(SetDownloadedRoutingTilesAction)
+    public setDownloadedRoutingTiles(ctx: StateContext<InMemoryState>, action: SetDownloadedRoutingTilesAction) {
+        ctx.setState(produce(ctx.getState(), lastState => {
+            lastState.downloadedRoutingTiles = action.downloadedRoutingTiles;
             return lastState;
         }));
     }

--- a/IsraelHiking.Web/src/application/reducers/in-memory.reducer.ts
+++ b/IsraelHiking.Web/src/application/reducers/in-memory.reducer.ts
@@ -1,4 +1,4 @@
-﻿import { State, Action, StateContext } from "@ngxs/store";
+import { State, Action, StateContext } from "@ngxs/store";
 import { Injectable } from "@angular/core";
 import { produce } from "immer";
 
@@ -56,11 +56,6 @@ export class SetEffectiveThemeAction {
 export class SetDownloadedTilesAction {
     public static readonly type = "[In Memory] SetDownloadedTilesAction";
     constructor(public readonly downloadedTiles: Record<string, FileNameDateVersion[]>) { }
-}
-
-export class SetDownloadedRoutingTilesAction {
-    public static readonly type = "[In Memory] SetDownloadedRoutingTilesAction";
-    constructor(public readonly downloadedRoutingTiles: string[]) { }
 }
 
 @State({
@@ -155,14 +150,6 @@ export class InMemoryReducer {
     public setDownloadedTiles(ctx: StateContext<InMemoryState>, action: SetDownloadedTilesAction) {
         ctx.setState(produce(ctx.getState(), lastState => {
             lastState.downloadedTiles = action.downloadedTiles;
-            return lastState;
-        }));
-    }
-
-    @Action(SetDownloadedRoutingTilesAction)
-    public setDownloadedRoutingTiles(ctx: StateContext<InMemoryState>, action: SetDownloadedRoutingTilesAction) {
-        ctx.setState(produce(ctx.getState(), lastState => {
-            lastState.downloadedRoutingTiles = action.downloadedRoutingTiles;
             return lastState;
         }));
     }

--- a/IsraelHiking.Web/src/application/reducers/initial-state.ts
+++ b/IsraelHiking.Web/src/application/reducers/initial-state.ts
@@ -224,7 +224,6 @@ export const initialState =
         inMemoryState: {
             effectiveTheme: "light",
             downloadedTiles: {},
-            downloadedRoutingTiles: [],
             distance: false,
             following: true,
             pannedTimestamp: null,

--- a/IsraelHiking.Web/src/application/reducers/initial-state.ts
+++ b/IsraelHiking.Web/src/application/reducers/initial-state.ts
@@ -223,6 +223,8 @@ export const initialState =
         },
         inMemoryState: {
             effectiveTheme: "light",
+            downloadedTiles: {},
+            downloadedRoutingTiles: [],
             distance: false,
             following: true,
             pannedTimestamp: null,
@@ -243,7 +245,6 @@ export const initialState =
         },
         offlineState: {
             isSubscribed: false,
-            downloadedTiles: null,
             uploadPoiQueue: [],
             lastOfflineDetectedDate: null
         },

--- a/IsraelHiking.Web/src/application/reducers/offline.reducer.ts
+++ b/IsraelHiking.Web/src/application/reducers/offline.reducer.ts
@@ -1,23 +1,13 @@
-import { State, Action, StateContext } from "@ngxs/store";
+﻿import { State, Action, StateContext } from "@ngxs/store";
 import { Injectable } from "@angular/core";
 import { produce } from "immer";
 
 import { initialState } from "./initial-state";
-import type { OfflineState, TileMetadataPerFile } from "../models";
+import type { OfflineState } from "../models";
 
 export class SetOfflineSubscribedAction {
     public static readonly type = "[Offline] SetOfflineSubscribedAction";
     constructor(public readonly isSubscribed: boolean) { }
-}
-
-export class SetOfflineMapsLastModifiedDateAction {
-    public static readonly type = "[Offline] SetOfflineMapsLastModifiedDateAction";
-    constructor(public readonly data: TileMetadataPerFile, public readonly tileX: number, public readonly tileY: number) { }
-}
-
-export class DeleteOfflineMapsTileAction {
-    public static readonly type = "[Offline] DeleteOfflineMapsTileAction";
-    constructor(public readonly tileX: number, public readonly tileY: number) { }
 }
 
 export class AddToPoiQueueAction {
@@ -46,31 +36,6 @@ export class OfflineReducer {
     public setOfflineSubscribed(ctx: StateContext<OfflineState>, action: SetOfflineSubscribedAction) {
         ctx.setState(produce(ctx.getState(), lastState => {
             lastState.isSubscribed = action.isSubscribed;
-            return lastState;
-        }));
-    }
-
-    @Action(SetOfflineMapsLastModifiedDateAction)
-    public setOfflineMpasLastModifiedDate(ctx: StateContext<OfflineState>, action: SetOfflineMapsLastModifiedDateAction) {
-        ctx.setState(produce(ctx.getState(), lastState => {
-            if (lastState.downloadedTiles == null) {
-                lastState.downloadedTiles = {};
-            }
-            lastState.downloadedTiles[`${action.tileX}-${action.tileY}`] = action.data;
-            return lastState;
-        }));
-    }
-
-    @Action(DeleteOfflineMapsTileAction)
-    public deleteOfflineMapsTile(ctx: StateContext<OfflineState>, action: DeleteOfflineMapsTileAction) {
-        ctx.setState(produce(ctx.getState(), lastState => {
-            if (lastState.downloadedTiles == null) {
-                return lastState;
-            }
-            delete lastState.downloadedTiles[`${action.tileX}-${action.tileY}`];
-            if (Object.keys(lastState.downloadedTiles).length === 0) {
-                lastState.downloadedTiles = undefined;
-            }
             return lastState;
         }));
     }

--- a/IsraelHiking.Web/src/application/reducers/offline.reducer.ts
+++ b/IsraelHiking.Web/src/application/reducers/offline.reducer.ts
@@ -1,4 +1,4 @@
-﻿import { State, Action, StateContext } from "@ngxs/store";
+import { State, Action, StateContext } from "@ngxs/store";
 import { Injectable } from "@angular/core";
 import { produce } from "immer";
 

--- a/IsraelHiking.Web/src/application/services/car.service.ts
+++ b/IsraelHiking.Web/src/application/services/car.service.ts
@@ -1,4 +1,4 @@
-import { inject, Service } from "@angular/core";
+﻿import { inject, Service } from "@angular/core";
 import { registerPlugin } from "@capacitor/core";
 import { Store } from "@ngxs/store";
 import { skip } from "rxjs";
@@ -39,7 +39,7 @@ export class CarService {
         this.store.select((state: ApplicationState) => state.layersState.selectedBaseLayerKey).pipe(skip(1)).subscribe(() => {
             this.setStyle();
         });
-        this.store.select((state: ApplicationState) => state.offlineState.downloadedTiles).pipe(skip(1)).subscribe(() => {
+        this.store.select((state: ApplicationState) => state.inMemoryState.downloadedTiles).pipe(skip(1)).subscribe(() => {
             this.setStyle();
         });
         this.store.select((state: ApplicationState) => state.routes.present).pipe(skip(1)).subscribe(() => {

--- a/IsraelHiking.Web/src/application/services/car.service.ts
+++ b/IsraelHiking.Web/src/application/services/car.service.ts
@@ -1,4 +1,4 @@
-﻿import { inject, Service } from "@angular/core";
+import { inject, Service } from "@angular/core";
 import { registerPlugin } from "@capacitor/core";
 import { Store } from "@ngxs/store";
 import { skip } from "rxjs";

--- a/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, vi, it, expect, Mock } from "vitest";
+﻿import { describe, beforeEach, vi, it, expect, Mock } from "vitest";
 import { inject, TestBed } from "@angular/core/testing";
 import { provideStore, Store } from "@ngxs/store";
 import type {
@@ -53,9 +53,8 @@ describe("DefaultStyleService", () => {
         });
 
         TestBed.inject(Store).reset({
-            offlineState: { downloadedTiles: null },
             configuration: { units: "metric" },
-            inMemoryState: { effectiveTheme: "light" }
+            inMemoryState: { effectiveTheme: "light", downloadedTiles: {} }
         });
     });
 
@@ -233,9 +232,8 @@ describe("DefaultStyleService", () => {
 
     it("should try getting the local style for a built-in base layer for offline mode", inject([DefaultStyleService, Store, FileService], async (service: DefaultStyleService, store: Store, fileService: FileService) => {
         store.reset({
-            offlineState: { downloadedTiles: {} },
             configuration: { units: "metric" },
-            inMemoryState: { effectiveTheme: "light" }
+            inMemoryState: { effectiveTheme: "light", downloadedTiles: { "76-51": [{ fileName: "IHM-schema+7-76-51.pmtiles", date: "2026-01-01" }] } }
         });
         (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({ version: 8, sources: {}, layers: [] }));
 
@@ -335,9 +333,8 @@ describe("DefaultStyleService", () => {
 
     it("should use the imperial multiplier for the contour source when units are imperial", inject([DefaultStyleService, Store, FileService], async (service: DefaultStyleService, store: Store, fileService: FileService) => {
         store.reset({
-            offlineState: { downloadedTiles: null },
             configuration: { units: "imperial" },
-            inMemoryState: { effectiveTheme: "light" }
+            inMemoryState: { effectiveTheme: "light", downloadedTiles: {} }
         });
         (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({
             version: 8,
@@ -379,9 +376,8 @@ describe("DefaultStyleService", () => {
 
     it("should tag the contour source with imperial units in car mode when configured", inject([DefaultStyleService, Store, FileService], async (service: DefaultStyleService, store: Store, fileService: FileService) => {
         store.reset({
-            offlineState: { downloadedTiles: null },
             configuration: { units: "imperial" },
-            inMemoryState: { effectiveTheme: "light" }
+            inMemoryState: { effectiveTheme: "light", downloadedTiles: {} }
         });
         (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({
             version: 8,
@@ -412,7 +408,7 @@ describe("DefaultStyleService", () => {
     }));
 
     it("should recolor the background and palette fills, leaving others untouched, when the theme is dark", inject([DefaultStyleService, Store, FileService], async (service: DefaultStyleService, store: Store, fileService: FileService) => {
-        store.reset({ offlineState: { downloadedTiles: null }, configuration: { units: "metric" }, inMemoryState: { effectiveTheme: "dark" } });
+        store.reset({ configuration: { units: "metric" }, inMemoryState: { effectiveTheme: "dark", downloadedTiles: {} } });
         (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({
             version: 8,
             sources: {},
@@ -464,7 +460,7 @@ describe("DefaultStyleService", () => {
     }));
 
     it("should not recolor any layer in car mode even when the theme is dark", inject([DefaultStyleService, Store, FileService], async (service: DefaultStyleService, store: Store, fileService: FileService) => {
-        store.reset({ offlineState: { downloadedTiles: null }, configuration: { units: "metric" }, inMemoryState: { effectiveTheme: "dark" } });
+        store.reset({ configuration: { units: "metric" }, inMemoryState: { effectiveTheme: "dark", downloadedTiles: {} } });
         (fileService.getStyleJsonContent as Mock).mockResolvedValue(JSON.stringify({
             version: 8,
             sources: {},

--- a/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.spec.ts
@@ -1,4 +1,4 @@
-﻿import { describe, beforeEach, vi, it, expect, Mock } from "vitest";
+import { describe, beforeEach, vi, it, expect, Mock } from "vitest";
 import { inject, TestBed } from "@angular/core/testing";
 import { provideStore, Store } from "@ngxs/store";
 import type {

--- a/IsraelHiking.Web/src/application/services/default-style.service.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.ts
@@ -1,4 +1,4 @@
-import { inject, Service } from "@angular/core";
+﻿import { inject, Service } from "@angular/core";
 import { Store } from "@ngxs/store";
 import type { RasterLayerSpecification, RasterSourceSpecification, StyleSpecification } from "maplibre-gl";
 
@@ -231,7 +231,8 @@ export class DefaultStyleService {
             return this.createRasterLayer(layerData, isVisible);
         } else {
             const isBuiltInBaseLayer = DEFAULT_BASE_LAYERS.some(l => l.key === layerData.key);
-            const tryLocalStyle = mode !== "online-only" && isBuiltInBaseLayer && this.store.selectSnapshot((s: ApplicationState) => s.offlineState).downloadedTiles != null;
+            const downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+            const tryLocalStyle = mode !== "online-only" && isBuiltInBaseLayer && Object.keys(downloadedTiles).length > 0;
             const language = this.resources.getCurrentLanguageCodeSimplified();
             const units = this.store.selectSnapshot((s: ApplicationState) => s.configuration.units);
 

--- a/IsraelHiking.Web/src/application/services/default-style.service.ts
+++ b/IsraelHiking.Web/src/application/services/default-style.service.ts
@@ -1,4 +1,4 @@
-﻿import { inject, Service } from "@angular/core";
+import { inject, Service } from "@angular/core";
 import { Store } from "@ngxs/store";
 import type { RasterLayerSpecification, RasterSourceSpecification, StyleSpecification } from "maplibre-gl";
 

--- a/IsraelHiking.Web/src/application/services/file.service.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.ts
@@ -1,4 +1,4 @@
-﻿import { inject, Service } from "@angular/core";
+import { inject, Service } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Directory, Encoding, Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";

--- a/IsraelHiking.Web/src/application/services/file.service.ts
+++ b/IsraelHiking.Web/src/application/services/file.service.ts
@@ -1,4 +1,4 @@
-import { inject, Service } from "@angular/core";
+﻿import { inject, Service } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Directory, Encoding, Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
@@ -52,8 +52,21 @@ export type HTMLElementInputChangeEvent = {
     preventDefault(): void;
 };
 
+/** A file in the app's data directory, the time it was last written to and its size in bytes */
+export type DataDirectoryFile = {
+    fileName: string;
+    modifiedDate: Date;
+    size: number;
+};
+
 @Service()
 export class FileService {
+    /**
+     * The offline files are downloaded into their own directory in the cache, so that they can be
+     * cleared without touching anything else that is cached.
+     */
+    private static readonly OFFLINE_CACHE_DIRECTORY = "offline-files";
+
 
     private readonly httpClient = inject(HttpClient);
     private readonly runningContextService = inject(RunningContextService);
@@ -322,8 +335,13 @@ export class FileService {
         return results.uri;
     }
 
+    /**
+     * Downloads an offline file into the offline files cache. A file that was not downloaded to its end,
+     * because the download was aborted or failed, is deleted - only whole files are left in the cache.
+     */
     public async downloadFileToCacheAuthenticated(url: string, fileName: string, token: string, progressCallback: (value: number) => void, abortController: AbortController): Promise<void> {
         this.loggingService.info(`[Files] Starting downloading and writing file to cache, file name ${fileName}`);
+        const path = FileService.offlineCachePath(fileName);
         let previousPercentage = 0;
         const response = await fetch(url, {
             headers: {
@@ -339,50 +357,117 @@ export class FileService {
         const contentLength = Number(response.headers.get("Content-Length"));
         let receivedLength = 0;
         let done: boolean;
-        do {
-            const readResult = await reader.read();
-            done = readResult.done;
-            if (done) {
-                break;
-            }
-            const value = readResult.value;
-            if (abortController.signal.aborted) {
-                this.loggingService.info(`[Files] Aborting download of file ${fileName}`);
-                return;
-            }
-
-            if (receivedLength === 0) {
-                await Filesystem.writeFile({
-                    path: fileName,
-                    directory: Directory.Cache,
-                    data: encode(value.buffer)
-                });
-            } else {
-                await Filesystem.appendFile({
-                    path: fileName,
-                    directory: Directory.Cache,
-                    data: encode(value.buffer)
-                });
-            }
-            receivedLength += value.length;
-            if (contentLength > 0) {
-                const currentPercentage = receivedLength / contentLength;
-                if (currentPercentage - previousPercentage > 0.001) {
-                    progressCallback(currentPercentage);
-                    previousPercentage = currentPercentage;
+        try {
+            do {
+                const readResult = await reader.read();
+                done = readResult.done;
+                if (done) {
+                    break;
                 }
-            }
-        } while (!done);
+                const value = readResult.value;
+                if (abortController.signal.aborted) {
+                    this.loggingService.info(`[Files] Aborting download of file ${fileName}`);
+                    await this.deleteFileInOfflineCache(fileName);
+                    return;
+                }
+
+                if (receivedLength === 0) {
+                    await Filesystem.writeFile({
+                        path,
+                        directory: Directory.Cache,
+                        data: encode(value.buffer),
+                        recursive: true
+                    });
+                } else {
+                    await Filesystem.appendFile({
+                        path,
+                        directory: Directory.Cache,
+                        data: encode(value.buffer)
+                    });
+                }
+                receivedLength += value.length;
+                if (contentLength > 0) {
+                    const currentPercentage = receivedLength / contentLength;
+                    if (currentPercentage - previousPercentage > 0.001) {
+                        progressCallback(currentPercentage);
+                        previousPercentage = currentPercentage;
+                    }
+                }
+            } while (!done);
+        } catch (ex) {
+            await this.deleteFileInOfflineCache(fileName);
+            throw ex;
+        }
         this.loggingService.info(`[Files] Finished downloading and writing file to cache, file name ${fileName}`);
     }
 
     public async moveFileFromCacheToDataDirectory(fileName: string): Promise<void> {
         await Filesystem.rename({
-            from: fileName,
+            from: FileService.offlineCachePath(fileName),
             to: fileName,
             directory: Directory.Cache,
             toDirectory: Directory.Data
         })
+    }
+
+    /**
+     * The offline files that were fully downloaded and are waiting to be moved to the data directory.
+     * They are only there while a download is going on, or after one that did not get to finish.
+     */
+    public async listFilesInOfflineCache(): Promise<string[]> {
+        try {
+            const results = await Filesystem.readdir({
+                path: FileService.OFFLINE_CACHE_DIRECTORY,
+                directory: Directory.Cache
+            });
+            return results.files.filter(f => f.type === "file").map(f => f.name);
+        } catch {
+            return []; // The directory is only there once something was downloaded into it
+        }
+    }
+
+    /**
+     * Removes whatever is left in the offline files cache, so that a download never continues from files
+     * that were downloaded in a previous run of the app and might not be the current ones anymore.
+     */
+    public async clearOfflineCache(): Promise<void> {
+        try {
+            await Filesystem.rmdir({
+                path: FileService.OFFLINE_CACHE_DIRECTORY,
+                directory: Directory.Cache,
+                recursive: true
+            });
+            this.loggingService.info("[Files] Cleared the offline files cache");
+        } catch {
+            // The directory is only there once something was downloaded into it
+        }
+    }
+
+    private async deleteFileInOfflineCache(fileName: string): Promise<void> {
+        try {
+            await Filesystem.deleteFile({
+                path: FileService.offlineCachePath(fileName),
+                directory: Directory.Cache
+            });
+        } catch (ex) {
+            this.loggingService.error(`[Files] Failed to delete the partial file: ${fileName}, ${(ex as Error).message}`);
+        }
+    }
+
+    private static offlineCachePath(fileName: string): string {
+        return `${FileService.OFFLINE_CACHE_DIRECTORY}/${fileName}`;
+    }
+
+    /**
+     * The files that are currently stored in the data directory, which is where the offline files are
+     * kept, with the time each of them was last written to. Directories are not returned, only files.
+     */
+    public async listFilesInDataDirectory(): Promise<DataDirectoryFile[]> {
+        const results = await Filesystem.readdir({
+            path: "",
+            directory: Directory.Data
+        });
+        return results.files.filter(f => f.type === "file").map(f => ({ fileName: f.name, modifiedDate: new Date(f.mtime), size: f.size }));
     }
 
     public async deleteFileInDataDirectory(fileName: string): Promise<void> {

--- a/IsraelHiking.Web/src/application/services/offline-files-download.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/offline-files-download.service.spec.ts
@@ -1,0 +1,559 @@
+﻿import { describe, beforeEach, vi, it, expect } from "vitest";
+import { TestBed, inject } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
+import { HttpTestingController, provideHttpClientTesting, type TestRequest } from "@angular/common/http/testing";
+import { provideStore, Store } from "@ngxs/store";
+
+import { OfflineFilesDownloadService } from "./offline-files-download.service";
+import { OfflineReducer } from "../reducers/offline.reducer";
+import { InMemoryReducer } from "../reducers/in-memory.reducer";
+import { FileService } from "./file.service";
+import { LoggingService } from "./logging.service";
+import { ToastService } from "./toast.service";
+import { ResourcesService } from "./resources.service";
+import { PmTilesService } from "./pmtiles.service";
+import { RoutingProvider } from "./routing.provider";
+import { RunningContextService } from "./running-context.service";
+import { Urls } from "../urls";
+import type { ApplicationState } from "../models";
+
+const ROOT_TILE_KEY = PmTilesService.toTileKey();
+const TILE_KEY = PmTilesService.toTileKey(76, 51);
+const MAP_FILE = "IHM-schema+7-76-51.pmtiles";
+const ROOT_MAP_FILE = "IHM-schema-6.pmtiles";
+const ROUTING_TILES_FILE = "valhalla+7-76-51.tar";
+const DOWNLOAD_DATE = new Date("2026-01-01T10:00:00.000Z");
+const FILE_SIZE = 1024 * 1024;
+
+/** The minimal version a style requires from each of its sources, keyed by the name used in the style */
+type MinVersions = Record<string, string>;
+
+/**
+ * The sources of the real styles - the name of a source and the name of the file it is downloaded as,
+ * taken from the source's url, are not the same.
+ */
+function createStyle(minVersions: MinVersions) {
+    return {
+        version: 8,
+        metadata: Object.fromEntries(Object.entries(minVersions).map(([name, version]) => [`sources:${name}:min-version`, version])),
+        sources: {
+            "IHM": { type: "vector", url: "https://mapeak.com/vector/data/IHM-schema.json" },
+            "IHM-code": { type: "vector", url: "https://mapeak.com/vector/data/IHM-code.json" },
+            "DEM": { type: "raster-dem", url: "https://global.israelhikingmap.workers.dev/raster-dem.json" }
+        },
+        layers: [] as object[]
+    };
+}
+
+/**
+ * Runs the initialization, which reads the files of the device into the state and the versions the
+ * styles require, with the routing tiles of the tile the tests use already downloaded.
+ */
+async function initialize(service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
+    hikeMinVersions: MinVersions, bikeMinVersions: MinVersions = {}) {
+    store.reset({
+        userState: { token: "token" },
+        offlineState: { isSubscribed: true },
+        inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+    });
+    const promise = service.initialize();
+    await flushStyles(mockBackend, hikeMinVersions, bikeMinVersions);
+    await promise;
+}
+
+async function flushStyles(mockBackend: HttpTestingController, hikeMinVersions: MinVersions, bikeMinVersions: MinVersions = {}) {
+    for (const [url, minVersions] of [[Urls.HIKING_STYLE_ADDRESS, hikeMinVersions], [Urls.MTB_STYLE_ADDRESS, bikeMinVersions]] as [string, MinVersions][]) {
+        await new Promise(resolve => setTimeout(resolve));
+        mockBackend.expectOne(url).flush(JSON.stringify(createStyle(minVersions)));
+    }
+}
+
+/** Answers the request for the list of files that need to be downloaded, for the root files or for a tile */
+async function flushFilesToDownload(mockBackend: HttpTestingController, forTile: boolean, files: Record<string, string>): Promise<TestRequest> {
+    await new Promise(resolve => setTimeout(resolve));
+    const request = mockBackend.expectOne(r => r.url === Urls.offlineFiles && r.params.has("tileX") === forTile);
+    request.flush(files);
+    return request;
+}
+
+describe("OfflineFilesDownloadService", () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                provideStore([OfflineReducer, InMemoryReducer]),
+                { provide: ResourcesService, useValue: { recommendOfflineDownload: "recommend-offline-download" } },
+                {
+                    provide: FileService, useValue: {
+                        writeStyle: vi.fn(() => Promise.resolve()),
+                        downloadFileToCacheAuthenticated: vi.fn(() => Promise.resolve()),
+                        moveFileFromCacheToDataDirectory: vi.fn(() => Promise.resolve()),
+                        deleteFileInDataDirectory: vi.fn(() => Promise.resolve()),
+                        listFilesInDataDirectory: vi.fn(() => Promise.resolve([MAP_FILE, ROOT_MAP_FILE].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })))),
+                        listFilesInOfflineCache: vi.fn(() => Promise.resolve([] as string[])),
+                        clearOfflineCache: vi.fn(() => Promise.resolve())
+                    }
+                },
+                { provide: LoggingService, useValue: { info: vi.fn(), debug: vi.fn(), warning: vi.fn(), error: vi.fn(), getErrorTypeAndMessage: () => ({ type: "client", message: "" }) } },
+                { provide: ToastService, useValue: { confirm: vi.fn() } },
+                { provide: PmTilesService, useValue: { getVersion: vi.fn((): Promise<string> => Promise.resolve(undefined)), invalidateFile: vi.fn() } },
+                {
+                    provide: RoutingProvider, useValue: {
+                        updateOfflineRoutingProfiles: vi.fn(() => Promise.resolve()),
+                        extractOfflineRoutingTiles: vi.fn(() => Promise.resolve()),
+                        deleteOfflineRoutingTiles: vi.fn(() => Promise.resolve()),
+                        getOfflineRoutingTiles: vi.fn(() => Promise.resolve([TILE_KEY]))
+                    }
+                },
+                { provide: RunningContextService, useValue: { isCapacitor: true } },
+                { provide: Router, useValue: { navigate: vi.fn() } },
+                OfflineFilesDownloadService,
+                provideHttpClient(withInterceptorsFromDi()),
+                provideHttpClientTesting()
+            ]
+        });
+    });
+
+    it("Should clear the offline files cache and read the files of the device into the state, keyed by the tile they belong to",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, fileService: FileService) => {
+                vi.mocked(fileService.listFilesInDataDirectory).mockResolvedValue(
+                    [MAP_FILE, "raster-dem+7-76-51.pmtiles", ROOT_MAP_FILE, "mapeak-hike.json"].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })));
+
+                await initialize(service, mockBackend, store, {});
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(downloadedTiles[TILE_KEY].map(f => f.fileName)).toEqual([MAP_FILE, "raster-dem+7-76-51.pmtiles"]);
+                expect(downloadedTiles[TILE_KEY][0].date).toBe(DOWNLOAD_DATE.toISOString());
+                expect(downloadedTiles[ROOT_TILE_KEY].map(f => f.fileName)).toEqual([ROOT_MAP_FILE]);
+                expect(fileService.clearOfflineCache).toHaveBeenCalled();
+            }
+        )
+    );
+
+    it("Should consider a tile compatible when the styles do not require any version, without reading any version",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                await initialize(service, mockBackend, store, {});
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(true);
+                expect(pmTilesService.getVersion).not.toHaveBeenCalled();
+            }
+        )
+    );
+
+    it("Should consider a tile incompatible when a file is older than the version required by the source it belongs to",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "2";
+                const versionTheStyleRequires = "3";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { IHM: versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(false);
+            }
+        )
+    );
+
+    it("Should consider a tile compatible when a file is newer than the version required by the source it belongs to",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "2";
+                const versionTheStyleRequires = "1";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { IHM: versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(true);
+            }
+        )
+    );
+
+    it("Should consider a tile incompatible when the required version is written using the name of the file",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "2";
+                const versionTheStyleRequires = "3";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { "IHM-schema": versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(false);
+            }
+        )
+    );
+
+    it("Should consider a tile incompatible when the required version is written using a different case",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "2";
+                const versionTheStyleRequires = "3";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { ihm: versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(false);
+            }
+        )
+    );
+
+    it("Should consider the root files, which have a zoom suffix instead of a tile one, incompatible when they are older than the version the style requires",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "2";
+                const versionTheStyleRequires = "3";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { IHM: versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(ROOT_TILE_KEY, downloadedTiles[ROOT_TILE_KEY])).toBe(false);
+            }
+        )
+    );
+
+    it("Should consider the root files, which have a zoom suffix instead of a tile one, compatible when they are new enough for the style",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "2";
+                const versionTheStyleRequires = "1";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { IHM: versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(ROOT_TILE_KEY, downloadedTiles[ROOT_TILE_KEY])).toBe(true);
+            }
+        )
+    );
+
+    it("Should compare versions numerically, so that a file at 1.10 is newer than the required 1.9",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "1.10";
+                const versionTheStyleRequires = "1.9";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { IHM: versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(true);
+            }
+        )
+    );
+
+    it("Should compare versions numerically, so that a file at 1.8 is older than the required 1.9",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "1.8";
+                const versionTheStyleRequires = "1.9";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                await initialize(service, mockBackend, store, { IHM: versionTheStyleRequires });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(false);
+            }
+        )
+    );
+
+    it("Should consider a tile incompatible when only one of the two styles requires a version the file is not at",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                const fileVersion = "2";
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(fileVersion);
+
+                // The hiking style is happy with the version the file is at, the bicycle one needs a newer file
+                await initialize(service, mockBackend, store, { IHM: fileVersion }, { "IHM-schema": "3" });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(false);
+            }
+        )
+    );
+
+    it("Should consider a file that has no version incompatible when the style requires one",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue(undefined); // The file holds no version
+                await initialize(service, mockBackend, store, { IHM: "2" }); // The style requires 2
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(false);
+            }
+        )
+    );
+
+    it("Should consider a tile compatible when the version is required from a source that is not in the style",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, pmTilesService: PmTilesService) => {
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue("2");
+
+                // Version 3 is required from a source that no style has, so it is required from no file
+                await initialize(service, mockBackend, store, { "a-source-that-does-not-exist": "3" });
+
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(service.isTileCompatible(TILE_KEY, downloadedTiles[TILE_KEY])).toBe(true);
+            }
+        )
+    );
+
+    it("Should consider a tile without routing tiles incompatible, but not the root files",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store) => {
+                await initialize(service, mockBackend, store, {});
+                store.reset({ inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] } });
+
+                expect(service.isTileCompatible(TILE_KEY, [{ fileName: MAP_FILE, date: "2026-01-01" }])).toBe(false);
+                expect(service.isTileCompatible(ROOT_TILE_KEY, [{ fileName: ROOT_MAP_FILE, date: "2026-01-01" }])).toBe(true);
+            }
+        )
+    );
+
+    it("Should tell that everything is up to date when downloading a tile that was just downloaded",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, fileService: FileService) => {
+                const downloadDate = new Date();
+                vi.mocked(fileService.listFilesInDataDirectory).mockResolvedValue([MAP_FILE, ROOT_MAP_FILE].map(fileName => ({ fileName, modifiedDate: downloadDate, size: FILE_SIZE })));
+                store.reset({
+                    userState: { token: "token" },
+                    offlineState: { isSubscribed: true },
+                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                });
+
+                const promise = service.downloadTile(76, 51);
+                await flushStyles(mockBackend, {});
+                const rootRequest = await flushFilesToDownload(mockBackend, false, {});
+                const tileRequest = await flushFilesToDownload(mockBackend, true, {});
+
+                expect(await promise).toBe("up-to-date");
+                expect(rootRequest.request.params.get("lastModified")).toBe(downloadDate.toISOString());
+                expect(tileRequest.request.params.get("lastModified")).toBe(downloadDate.toISOString());
+            }
+        )
+    );
+
+    it("Should move the files that were downloaded, read them into the state and store the routing tiles on their own",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService, RoutingProvider],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
+                fileService: FileService, routingProvider: RoutingProvider) => {
+                vi.mocked(fileService.listFilesInDataDirectory)
+                    .mockResolvedValueOnce(["raster-dem+7-76-51.pmtiles"].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })))
+                    .mockResolvedValue(["raster-dem+7-76-51.pmtiles", MAP_FILE].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })));
+                vi.mocked(routingProvider.getOfflineRoutingTiles).mockResolvedValueOnce([]).mockResolvedValue([TILE_KEY]);
+                store.reset({
+                    userState: { token: "token" },
+                    offlineState: { isSubscribed: true },
+                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                });
+
+                const promise = service.downloadTile(76, 51);
+                await flushStyles(mockBackend, {});
+                await flushFilesToDownload(mockBackend, false, {});
+                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01", [ROUTING_TILES_FILE]: "2026-06-01" });
+
+                expect(await promise).toBe("downloaded");
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(downloadedTiles[TILE_KEY].map(f => f.fileName)).toEqual(["raster-dem+7-76-51.pmtiles", MAP_FILE]);
+                expect(fileService.moveFileFromCacheToDataDirectory).toHaveBeenCalledWith(MAP_FILE);
+                expect(fileService.moveFileFromCacheToDataDirectory).toHaveBeenCalledWith(ROUTING_TILES_FILE);
+                expect(routingProvider.extractOfflineRoutingTiles).toHaveBeenCalledWith(ROUTING_TILES_FILE, TILE_KEY);
+                expect(store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles)).toEqual([TILE_KEY]);
+            }
+        )
+    );
+
+    it("Should report a download that was aborted while its files were being downloaded as aborted",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, fileService: FileService) => {
+                store.reset({
+                    userState: { token: "token" },
+                    offlineState: { isSubscribed: true },
+                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                });
+                // Aborting a download makes the request of every file that is being downloaded fail
+                vi.mocked(fileService.downloadFileToCacheAuthenticated).mockImplementation(() => {
+                    service.abortCurrentDownload();
+                    return Promise.reject(new DOMException("The user aborted a request.", "AbortError"));
+                });
+
+                const promise = service.downloadTile(76, 51);
+                await flushStyles(mockBackend, {});
+                await flushFilesToDownload(mockBackend, false, {});
+                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01" });
+
+                expect(await promise).toBe("aborted");
+                expect(fileService.moveFileFromCacheToDataDirectory).not.toHaveBeenCalled();
+            }
+        )
+    );
+
+    it("Should keep the download that was started after an abort, even when the aborted one is still unwinding",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, fileService: FileService) => {
+                store.reset({
+                    userState: { token: "token" },
+                    offlineState: { isSubscribed: true },
+                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                });
+                const stuckDownloads: (() => void)[] = [];
+                const progressCallbacks: ((value: number) => void)[] = [];
+                vi.mocked(fileService.downloadFileToCacheAuthenticated).mockImplementation(
+                    (_url, _fileName, _token, progressCallback) => {
+                        progressCallbacks.push(progressCallback);
+                        return new Promise(resolve => stuckDownloads.push(resolve));
+                    });
+
+                const stuckPromise = service.downloadTile(76, 51);
+                await flushStyles(mockBackend, {});
+                await flushFilesToDownload(mockBackend, false, {});
+                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01" });
+                await new Promise(resolve => setTimeout(resolve));
+                expect(stuckDownloads.length).toBe(1);
+
+                service.abortCurrentDownload();
+                const secondPromise = service.downloadTile(76, 52);
+                await flushStyles(mockBackend, {});
+                await flushFilesToDownload(mockBackend, false, {});
+                await flushFilesToDownload(mockBackend, true, { "IHM-schema+7-76-52.pmtiles": "2026-06-01" });
+                await new Promise(resolve => setTimeout(resolve));
+
+                // The download that was aborted reports its progress before it returns, which is not the progress of the one going on
+                progressCallbacks[0](0.5);
+                expect(service.currentDownloadedTile()).toEqual({ tileX: 76, tileY: 52, progress: 0 });
+
+                stuckDownloads[0](); // the download that was stuck finally returns
+                expect(await stuckPromise).toBe("aborted");
+                expect(service.currentDownloadedTile()).toEqual({ tileX: 76, tileY: 52, progress: 0 });
+
+                progressCallbacks[1](0.5);
+                expect(service.currentDownloadedTile()).toEqual({ tileX: 76, tileY: 52, progress: 50 });
+
+                stuckDownloads[1]();
+                expect(await secondPromise).toBe("downloaded");
+                expect(service.currentDownloadedTile()).toBeNull();
+            }
+        )
+    );
+
+    it("Should not download again a file that is already in the cache from a download that did not finish",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, fileService: FileService) => {
+                store.reset({
+                    userState: { token: "token" },
+                    offlineState: { isSubscribed: true },
+                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                });
+                vi.mocked(fileService.listFilesInOfflineCache).mockResolvedValue([MAP_FILE]);
+
+                const promise = service.downloadTile(76, 51);
+                await flushStyles(mockBackend, {});
+                await flushFilesToDownload(mockBackend, false, {});
+                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01", [ROUTING_TILES_FILE]: "2026-06-01" });
+
+                expect(await promise).toBe("downloaded");
+                expect(fileService.downloadFileToCacheAuthenticated).toHaveBeenCalledTimes(1);
+                expect(fileService.downloadFileToCacheAuthenticated).toHaveBeenCalledWith(
+                    expect.stringContaining(ROUTING_TILES_FILE), ROUTING_TILES_FILE, "token", expect.any(Function), expect.any(AbortController));
+                expect(fileService.moveFileFromCacheToDataDirectory).toHaveBeenCalledWith(MAP_FILE);
+            }
+        )
+    );
+
+    it("Should delete the files of sources that the styles no longer use when a tile is downloaded",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, fileService: FileService) => {
+                vi.mocked(fileService.listFilesInDataDirectory).mockResolvedValue([
+                    MAP_FILE,
+                    "global_points+7-76-51.pmtiles",
+                    "a-removed-source+7-76-51.pmtiles",
+                    "a-removed-source-6.pmtiles",
+                    "mapeak-hike.json"
+                ].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })));
+                store.reset({
+                    userState: { token: "token" },
+                    offlineState: { isSubscribed: true },
+                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                });
+
+                const promise = service.downloadTile(76, 51);
+                await flushStyles(mockBackend, {});
+                await flushFilesToDownload(mockBackend, false, {});
+                await flushFilesToDownload(mockBackend, true, {});
+
+                expect(await promise).toBe("up-to-date");
+                expect(fileService.deleteFileInDataDirectory).toHaveBeenCalledWith("a-removed-source+7-76-51.pmtiles");
+                expect(fileService.deleteFileInDataDirectory).toHaveBeenCalledWith("a-removed-source-6.pmtiles");
+                expect(fileService.deleteFileInDataDirectory).not.toHaveBeenCalledWith(MAP_FILE);
+                expect(fileService.deleteFileInDataDirectory).not.toHaveBeenCalledWith("global_points+7-76-51.pmtiles");
+                expect(fileService.deleteFileInDataDirectory).not.toHaveBeenCalledWith("mapeak-hike.json");
+            }
+        )
+    );
+
+    it("Should delete the files and the routing tiles of a tile, and read what is left from the device",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService, RoutingProvider],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
+                fileService: FileService, routingProvider: RoutingProvider) => {
+                await initialize(service, mockBackend, store, {});
+                vi.mocked(fileService.listFilesInDataDirectory).mockResolvedValue([ROOT_MAP_FILE].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })));
+                vi.mocked(routingProvider.getOfflineRoutingTiles).mockResolvedValue([]);
+
+                await service.deleteTile(TILE_KEY);
+
+                expect(fileService.deleteFileInDataDirectory).toHaveBeenCalledWith(MAP_FILE);
+                expect(routingProvider.deleteOfflineRoutingTiles).toHaveBeenCalledWith(TILE_KEY);
+                expect(store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles)).toEqual([]);
+                const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+                expect(downloadedTiles[TILE_KEY]).toBeUndefined();
+            }
+        )
+    );
+
+    it("Should recommend to download again when a downloaded tile is not compatible",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, ToastService, FileService, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
+                toastService: ToastService, fileService: FileService, pmTilesService: PmTilesService) => {
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue("2"); // The files are at version 2
+
+                await initialize(service, mockBackend, store, { IHM: "3" }); // The style requires 3
+
+                expect(toastService.confirm).toHaveBeenCalled();
+                expect(fileService.writeStyle).not.toHaveBeenCalled();
+            }
+        )
+    );
+
+    it("Should store the styles and not recommend to download again when the downloaded tiles are compatible",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, ToastService, FileService, PmTilesService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
+                toastService: ToastService, fileService: FileService, pmTilesService: PmTilesService) => {
+                vi.mocked(pmTilesService.getVersion).mockResolvedValue("2"); // The files are at version 2
+
+                await initialize(service, mockBackend, store, { IHM: "2" }); // The style requires 2
+
+                expect(toastService.confirm).not.toHaveBeenCalled();
+                expect(fileService.writeStyle).toHaveBeenCalledTimes(2);
+            }
+        )
+    );
+
+    it("Should recommend downloading when the device holds no offline files",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, ToastService, FileService],
+            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
+                toastService: ToastService, fileService: FileService) => {
+                vi.mocked(fileService.listFilesInDataDirectory).mockResolvedValue([]);
+
+                await initialize(service, mockBackend, store, {});
+
+                expect(toastService.confirm).toHaveBeenCalled();
+            }
+        )
+    );
+});

--- a/IsraelHiking.Web/src/application/services/offline-files-download.service.spec.ts
+++ b/IsraelHiking.Web/src/application/services/offline-files-download.service.spec.ts
@@ -13,7 +13,6 @@ import { LoggingService } from "./logging.service";
 import { ToastService } from "./toast.service";
 import { ResourcesService } from "./resources.service";
 import { PmTilesService } from "./pmtiles.service";
-import { RoutingProvider } from "./routing.provider";
 import { RunningContextService } from "./running-context.service";
 import { Urls } from "../urls";
 import type { ApplicationState } from "../models";
@@ -22,7 +21,6 @@ const ROOT_TILE_KEY = PmTilesService.toTileKey();
 const TILE_KEY = PmTilesService.toTileKey(76, 51);
 const MAP_FILE = "IHM-schema+7-76-51.pmtiles";
 const ROOT_MAP_FILE = "IHM-schema-6.pmtiles";
-const ROUTING_TILES_FILE = "valhalla+7-76-51.tar";
 const DOWNLOAD_DATE = new Date("2026-01-01T10:00:00.000Z");
 const FILE_SIZE = 1024 * 1024;
 
@@ -48,14 +46,14 @@ function createStyle(minVersions: MinVersions) {
 
 /**
  * Runs the initialization, which reads the files of the device into the state and the versions the
- * styles require, with the routing tiles of the tile the tests use already downloaded.
+ * styles require.
  */
 async function initialize(service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
     hikeMinVersions: MinVersions, bikeMinVersions: MinVersions = {}) {
     store.reset({
         userState: { token: "token" },
         offlineState: { isSubscribed: true },
-        inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+        inMemoryState: { downloadedTiles: {} }
     });
     const promise = service.initialize();
     await flushStyles(mockBackend, hikeMinVersions, bikeMinVersions);
@@ -97,14 +95,6 @@ describe("OfflineFilesDownloadService", () => {
                 { provide: LoggingService, useValue: { info: vi.fn(), debug: vi.fn(), warning: vi.fn(), error: vi.fn(), getErrorTypeAndMessage: () => ({ type: "client", message: "" }) } },
                 { provide: ToastService, useValue: { confirm: vi.fn() } },
                 { provide: PmTilesService, useValue: { getVersion: vi.fn((): Promise<string> => Promise.resolve(undefined)), invalidateFile: vi.fn() } },
-                {
-                    provide: RoutingProvider, useValue: {
-                        updateOfflineRoutingProfiles: vi.fn(() => Promise.resolve()),
-                        extractOfflineRoutingTiles: vi.fn(() => Promise.resolve()),
-                        deleteOfflineRoutingTiles: vi.fn(() => Promise.resolve()),
-                        getOfflineRoutingTiles: vi.fn(() => Promise.resolve([TILE_KEY]))
-                    }
-                },
                 { provide: RunningContextService, useValue: { isCapacitor: true } },
                 { provide: Router, useValue: { navigate: vi.fn() } },
                 OfflineFilesDownloadService,
@@ -304,18 +294,6 @@ describe("OfflineFilesDownloadService", () => {
         )
     );
 
-    it("Should consider a tile without routing tiles incompatible, but not the root files",
-        inject([OfflineFilesDownloadService, HttpTestingController, Store],
-            async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store) => {
-                await initialize(service, mockBackend, store, {});
-                store.reset({ inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] } });
-
-                expect(service.isTileCompatible(TILE_KEY, [{ fileName: MAP_FILE, date: "2026-01-01" }])).toBe(false);
-                expect(service.isTileCompatible(ROOT_TILE_KEY, [{ fileName: ROOT_MAP_FILE, date: "2026-01-01" }])).toBe(true);
-            }
-        )
-    );
-
     it("Should tell that everything is up to date when downloading a tile that was just downloaded",
         inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
             async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store, fileService: FileService) => {
@@ -324,7 +302,7 @@ describe("OfflineFilesDownloadService", () => {
                 store.reset({
                     userState: { token: "token" },
                     offlineState: { isSubscribed: true },
-                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                    inMemoryState: { downloadedTiles: {} }
                 });
 
                 const promise = service.downloadTile(76, 51);
@@ -339,32 +317,28 @@ describe("OfflineFilesDownloadService", () => {
         )
     );
 
-    it("Should move the files that were downloaded, read them into the state and store the routing tiles on their own",
-        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService, RoutingProvider],
+    it("Should move the files that were downloaded and read them into the state",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
             async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
-                fileService: FileService, routingProvider: RoutingProvider) => {
+                fileService: FileService) => {
                 vi.mocked(fileService.listFilesInDataDirectory)
                     .mockResolvedValueOnce(["raster-dem+7-76-51.pmtiles"].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })))
                     .mockResolvedValue(["raster-dem+7-76-51.pmtiles", MAP_FILE].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })));
-                vi.mocked(routingProvider.getOfflineRoutingTiles).mockResolvedValueOnce([]).mockResolvedValue([TILE_KEY]);
                 store.reset({
                     userState: { token: "token" },
                     offlineState: { isSubscribed: true },
-                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                    inMemoryState: { downloadedTiles: {} }
                 });
 
                 const promise = service.downloadTile(76, 51);
                 await flushStyles(mockBackend, {});
                 await flushFilesToDownload(mockBackend, false, {});
-                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01", [ROUTING_TILES_FILE]: "2026-06-01" });
+                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01" });
 
                 expect(await promise).toBe("downloaded");
                 const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
                 expect(downloadedTiles[TILE_KEY].map(f => f.fileName)).toEqual(["raster-dem+7-76-51.pmtiles", MAP_FILE]);
                 expect(fileService.moveFileFromCacheToDataDirectory).toHaveBeenCalledWith(MAP_FILE);
-                expect(fileService.moveFileFromCacheToDataDirectory).toHaveBeenCalledWith(ROUTING_TILES_FILE);
-                expect(routingProvider.extractOfflineRoutingTiles).toHaveBeenCalledWith(ROUTING_TILES_FILE, TILE_KEY);
-                expect(store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles)).toEqual([TILE_KEY]);
             }
         )
     );
@@ -375,7 +349,7 @@ describe("OfflineFilesDownloadService", () => {
                 store.reset({
                     userState: { token: "token" },
                     offlineState: { isSubscribed: true },
-                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                    inMemoryState: { downloadedTiles: {} }
                 });
                 // Aborting a download makes the request of every file that is being downloaded fail
                 vi.mocked(fileService.downloadFileToCacheAuthenticated).mockImplementation(() => {
@@ -400,7 +374,7 @@ describe("OfflineFilesDownloadService", () => {
                 store.reset({
                     userState: { token: "token" },
                     offlineState: { isSubscribed: true },
-                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                    inMemoryState: { downloadedTiles: {} }
                 });
                 const stuckDownloads: (() => void)[] = [];
                 const progressCallbacks: ((value: number) => void)[] = [];
@@ -448,19 +422,19 @@ describe("OfflineFilesDownloadService", () => {
                 store.reset({
                     userState: { token: "token" },
                     offlineState: { isSubscribed: true },
-                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                    inMemoryState: { downloadedTiles: {} }
                 });
                 vi.mocked(fileService.listFilesInOfflineCache).mockResolvedValue([MAP_FILE]);
 
                 const promise = service.downloadTile(76, 51);
                 await flushStyles(mockBackend, {});
                 await flushFilesToDownload(mockBackend, false, {});
-                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01", [ROUTING_TILES_FILE]: "2026-06-01" });
+                await flushFilesToDownload(mockBackend, true, { [MAP_FILE]: "2026-06-01", "raster-dem+7-76-51.pmtiles": "2026-06-01" });
 
                 expect(await promise).toBe("downloaded");
                 expect(fileService.downloadFileToCacheAuthenticated).toHaveBeenCalledTimes(1);
                 expect(fileService.downloadFileToCacheAuthenticated).toHaveBeenCalledWith(
-                    expect.stringContaining(ROUTING_TILES_FILE), ROUTING_TILES_FILE, "token", expect.any(Function), expect.any(AbortController));
+                    expect.stringContaining("raster-dem+7-76-51.pmtiles"), "raster-dem+7-76-51.pmtiles", "token", expect.any(Function), expect.any(AbortController));
                 expect(fileService.moveFileFromCacheToDataDirectory).toHaveBeenCalledWith(MAP_FILE);
             }
         )
@@ -479,7 +453,7 @@ describe("OfflineFilesDownloadService", () => {
                 store.reset({
                     userState: { token: "token" },
                     offlineState: { isSubscribed: true },
-                    inMemoryState: { downloadedTiles: {}, downloadedRoutingTiles: [] }
+                    inMemoryState: { downloadedTiles: {} }
                 });
 
                 const promise = service.downloadTile(76, 51);
@@ -497,19 +471,16 @@ describe("OfflineFilesDownloadService", () => {
         )
     );
 
-    it("Should delete the files and the routing tiles of a tile, and read what is left from the device",
-        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService, RoutingProvider],
+    it("Should delete the files of a tile and read what is left from the device",
+        inject([OfflineFilesDownloadService, HttpTestingController, Store, FileService],
             async (service: OfflineFilesDownloadService, mockBackend: HttpTestingController, store: Store,
-                fileService: FileService, routingProvider: RoutingProvider) => {
+                fileService: FileService) => {
                 await initialize(service, mockBackend, store, {});
                 vi.mocked(fileService.listFilesInDataDirectory).mockResolvedValue([ROOT_MAP_FILE].map(fileName => ({ fileName, modifiedDate: DOWNLOAD_DATE, size: FILE_SIZE })));
-                vi.mocked(routingProvider.getOfflineRoutingTiles).mockResolvedValue([]);
 
                 await service.deleteTile(TILE_KEY);
 
                 expect(fileService.deleteFileInDataDirectory).toHaveBeenCalledWith(MAP_FILE);
-                expect(routingProvider.deleteOfflineRoutingTiles).toHaveBeenCalledWith(TILE_KEY);
-                expect(store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles)).toEqual([]);
                 const downloadedTiles = store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
                 expect(downloadedTiles[TILE_KEY]).toBeUndefined();
             }

--- a/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
+++ b/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, inject, Service } from "@angular/core";
+﻿import { computed, inject, Service, signal } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Router } from "@angular/router";
 import { timeout } from "rxjs/operators";
@@ -10,37 +10,85 @@ import pLimit from "p-limit";
 import type { StyleSpecification } from "maplibre-gl";
 
 import { Urls } from "../urls";
-import { FileService } from "./file.service";
+import { FileService, type DataDirectoryFile } from "./file.service";
 import { LoggingService } from "./logging.service";
 import { ToastService } from "./toast.service";
 import { ResourcesService } from "./resources.service";
 import { PmTilesService } from "./pmtiles.service";
+import { RoutingProvider } from "./routing.provider";
+import { RunningContextService } from "./running-context.service";
 import { RouteStrings } from "./hash.service";
-import { DeleteOfflineMapsTileAction, SetOfflineMapsLastModifiedDateAction } from "../reducers/offline.reducer";
-import type { ApplicationState, FileNameDateVersion, TileMetadataPerFile } from "../models";
+import { SetDownloadedRoutingTilesAction, SetDownloadedTilesAction } from "../reducers/in-memory.reducer";
+import type { ApplicationState, FileNameDateVersion } from "../models";
+
+/** What the styles need from the offline files, see readStyleRequirements */
+type StyleRequirements = {
+    /** The minimal version a source file needs to be at, keyed by the lower cased name of that file */
+    minVersionPerFile: Record<string, string>;
+    /** The lower cased names of the files of the sources the styles use */
+    sourceFileNames: string[];
+};
+
+/** The download that is going on right now, everything that lives as long as it does */
+type CurrentDownload = {
+    tileX: number;
+    tileY: number;
+    /** How much of the tile was downloaded so far, from 0 to 100 */
+    progress: number;
+    /** Identifies the download - a new one gets a new controller, and only it can abort it */
+    abortController: AbortController;
+};
 
 @Service()
 export class OfflineFilesDownloadService {
+    /** The metadata key a style uses to declare the minimal version it needs from one of its sources */
+    private static readonly MIN_VERSION_KEY_REGEX = /^sources:(.+):min-version$/;
+
+    /** The extension of the offline map files, the only files in the data directory this service owns */
+    private static readonly OFFLINE_FILE_EXTENSION = ".pmtiles";
+
+    /**
+     * Sources the app adds by itself instead of taking them from the style, see the public pois component.
+     * Their files are downloaded and needed like the files of the style's own sources.
+     */
+    private static readonly APPLICATION_SOURCE_FILE_NAMES = ["global_points"];
+
     private readonly resources = inject(ResourcesService);
     private readonly fileService = inject(FileService);
     private readonly loggingService = inject(LoggingService);
     private readonly httpClient = inject(HttpClient);
     private readonly toastService = inject(ToastService);
     private readonly pmtilesService = inject(PmTilesService);
+    private readonly routingProvider = inject(RoutingProvider);
+    private readonly runningContextService = inject(RunningContextService);
     private readonly store = inject(Store);
     private readonly router = inject(Router);
 
-    private metadata: Record<string, string> = {};
-    private abortController = new AbortController();
-    private downloadedFilesInCurrentSession: string[] = [];
-    private _currentDownloadedTile: { tileX: number, tileY: number, progress: Record<number, number> } | null = null;
+    /** What the styles need from the offline files, read from them every time they are downloaded */
+    private styleRequirements: StyleRequirements = { minVersionPerFile: {}, sourceFileNames: [] };
+    private readonly currentDownload = signal<CurrentDownload | null>(null);
 
-    public readonly tilesProgressChanged = new EventEmitter<{ tileX: number, tileY: number, progressValue: number }>();
-    public get currentDownloadedTile() {
-        return this._currentDownloadedTile;
-    }
+    /** The tile that is being downloaded right now and how far it got, null when there is no download */
+    public readonly currentDownloadedTile = computed(() => {
+        const currentDownload = this.currentDownload();
+        return currentDownload == null
+            ? null
+            : { tileX: currentDownload.tileX, tileY: currentDownload.tileY, progress: currentDownload.progress };
+    });
 
+    /**
+     * Reads what was downloaded into the state, and when there's a reason to, recommends downloading it
+     * again. Whoever needs to know what is on the device reacts to the state changing, so there's no need
+     * to wait for this before the app is up.
+     * The files are read for every user of the app, a user whose subscription ended still has them and
+     * should be offered to renew it rather than to buy it, but only the device holds any.
+     */
     public async initialize(): Promise<void> {
+        if (!this.runningContextService.isCapacitor) {
+            return;
+        }
+        await this.fileService.clearOfflineCache();
+        await this.updateDownloadedTilesFromDevice();
         const offlineState = this.store.selectSnapshot((s: ApplicationState) => s.offlineState);
         const userState = this.store.selectSnapshot((s: ApplicationState) => s.userState);
         if (userState == null || offlineState.isSubscribed === false) {
@@ -48,7 +96,15 @@ export class OfflineFilesDownloadService {
         }
         try {
             const styles = await this.downloadStyleAndUpdateMetadata();
-            const needToAskToRedownload = offlineState.downloadedTiles == null || Object.values(offlineState.downloadedTiles).some(dt => !this.isTileCompatible(dt));
+            await this.updateVersionsOfDownloadedFiles();
+            const downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+            const incompatibleTileKeys = Object.entries(downloadedTiles)
+                .filter(([tileKey, files]) => !this.isTileCompatible(tileKey, files))
+                .map(([tileKey]) => tileKey);
+            if (incompatibleTileKeys.length > 0) {
+                this.loggingService.info(`[Offline Download] These tiles need to be downloaded again: ${incompatibleTileKeys.join(", ")}`);
+            }
+            const needToAskToRedownload = Object.keys(downloadedTiles).length === 0 || incompatibleTileKeys.length > 0;
             if (!needToAskToRedownload) {
                 for (const styleAndContent of styles) {
                     await this.fileService.writeStyle(styleAndContent.fileName, styleAndContent.content);
@@ -73,44 +129,136 @@ export class OfflineFilesDownloadService {
             const style = await firstValueFrom(this.httpClient.get(baseLayerUrl, { responseType: "text" }).pipe(timeout(5000)));
             styles.push({ fileName: last(baseLayerUrl.split("/")), content: style });
         }
-        this.metadata = {};
+        this.styleRequirements = { minVersionPerFile: {}, sourceFileNames: [] };
         for (const style of styles) {
-            this.metadata = Object.assign(this.metadata, (JSON.parse(style.content) as StyleSpecification).metadata as Record<string, string>);
+            this.readStyleRequirements(JSON.parse(style.content) as StyleSpecification);
         }
         return styles;
     }
 
+    /**
+     * A style declares the minimal version it needs from a source using a "sources:{name}:min-version" metadata
+     * key, but the offline files are named after the file the source's url points to and not after the name of
+     * the source in the style - the "IHM" source, for example, is downloaded as "IHM-schema+7-x-y.pmtiles".
+     * This translates every such key to the name of the file it refers to, accepting a key that is written using
+     * either name, so that a mismatch between the two does not silently skip the version check.
+     * When both styles require a version from the same file the stricter one wins.
+     */
+    private readStyleRequirements(style: StyleSpecification): void {
+        const fileNamePerSourceName: Record<string, string> = {};
+        for (const [sourceName, source] of Object.entries(style.sources ?? {})) {
+            const fileName = OfflineFilesDownloadService.getFileNameFromUrl((source as { url?: string }).url);
+            if (fileName != null) {
+                fileNamePerSourceName[sourceName.toLowerCase()] = fileName;
+            }
+        }
+        const knownFileNames = Object.values(fileNamePerSourceName).map(f => f.toLowerCase());
+        this.styleRequirements.sourceFileNames = [...new Set([...this.styleRequirements.sourceFileNames, ...knownFileNames])];
+        for (const [key, minVersion] of Object.entries((style.metadata ?? {}) as Record<string, string>)) {
+            const name = OfflineFilesDownloadService.MIN_VERSION_KEY_REGEX.exec(key)?.[1];
+            if (name == null || !minVersion) {
+                continue;
+            }
+            const fileName = (fileNamePerSourceName[name.toLowerCase()] ?? name).toLowerCase();
+            if (!knownFileNames.includes(fileName)) {
+                this.loggingService.warning(`[Offline Download] The style requires version ${minVersion} from "${name}", ` +
+                    "which is not a source of the style, using it as a file name");
+            }
+            const currentMinVersion = this.styleRequirements.minVersionPerFile[fileName];
+            if (currentMinVersion == null || OfflineFilesDownloadService.compareVersions(minVersion, currentMinVersion) > 0) {
+                this.styleRequirements.minVersionPerFile[fileName] = minVersion;
+            }
+        }
+    }
+
+    /**
+     * The name of the file a source's url points to, without its extension, which is also the name the server
+     * gives the offline files of that source: "https://mapeak.com/vector/data/IHM-schema.json" is "IHM-schema".
+     */
+    private static getFileNameFromUrl(url: string | undefined): string | null {
+        const lastPart = last((url ?? "").split("?")[0].split("/"));
+        return lastPart ? OfflineFilesDownloadService.removeExtension(lastPart) : null;
+    }
+
+    /**
+     * The name of the source file an offline file holds, as the server names them: tile files look like
+     * "name+7-x-y.pmtiles" and root files like "name-6.pmtiles", where the name itself may contain a "-".
+     */
+    private static getSourceFileName(fileName: string): string {
+        const plusIndex = fileName.indexOf("+");
+        if (plusIndex >= 0) {
+            return fileName.substring(0, plusIndex);
+        }
+        return OfflineFilesDownloadService.removeExtension(fileName).replace(/-\d+$/, "");
+    }
+
+    /**
+     * The id of the tile an offline file belongs to, taken from its name: a tile file is named
+     * "name+7-x-y.pmtiles" while a root file, which is not of a specific tile, is named "name-6.pmtiles".
+     * Returns null for a file that is named like neither of them.
+     */
+    private static getTileKey(fileName: string): string | null {
+        const plusIndex = fileName.indexOf("+");
+        if (plusIndex < 0) {
+            return PmTilesService.toTileKey();
+        }
+        const zoomAndTile = OfflineFilesDownloadService.removeExtension(fileName.substring(plusIndex + 1));
+        const tileKey = zoomAndTile.substring(zoomAndTile.indexOf("-") + 1);
+        return PmTilesService.fromTileKey(tileKey) == null ? null : tileKey;
+    }
+
+    private static removeExtension(fileName: string): string {
+        const dotIndex = fileName.lastIndexOf(".");
+        return dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
+    }
+
+    /** Compares two versions numerically, so that "1.10" is newer than "1.9" */
+    private static compareVersions(version: string, otherVersion: string): number {
+        return version.localeCompare(otherVersion, undefined, { numeric: true, sensitivity: "base" });
+    }
+
+    /**
+     * Downloads everything a tile needs. A download that is still going on when this is called is aborted
+     * first, so that the one the user asked for last is the only one that goes on.
+     */
     public async downloadTile(tileX: number, tileY: number): Promise<"up-to-date" | "downloaded" | "error" | "aborted"> {
-        this._currentDownloadedTile = { tileX, tileY, progress: {} };
-        this.loggingService.info("[Offline Download] Starting downloading offline files");
+        this.abortCurrentDownload();
+        const currentDownload: CurrentDownload = { tileX, tileY, progress: 0, abortController: new AbortController() };
+        this.currentDownload.set(currentDownload);
+        this.loggingService.info(`[Offline Download] Starting downloading the offline files of ${PmTilesService.toTileKey(tileX, tileY)}`);
         try {
             const styles = await this.downloadStyleAndUpdateMetadata();
             for (const styleAndContent of styles) {
                 await this.fileService.writeStyle(styleAndContent.fileName, styleAndContent.content);
             }
+            await this.routingProvider.updateOfflineRoutingProfiles();
+            await this.deleteFilesOfUnusedSources();
+            // What is asked of the server is decided by the state, so it is read again now that files were deleted
+            await this.updateDownloadedTilesFromDevice();
             const fileNamesForRoot = await this.getFilesToDownload();
             const fileNamesForTile = await this.getFilesToDownload(tileX, tileY);
             if (fileNamesForTile.length === 0 && fileNamesForRoot.length === 0) {
                 this.loggingService.info("[Offline Download] No files to download, all files are up to date");
                 return "up-to-date";
             }
-            this.updateInProgressTilesList(0, -1, 0);
             const fileNames = [...fileNamesForRoot, ...fileNamesForTile];
-            const currentAbortController = this.abortController; // keep a referece to the current abort controller for the case of aborting and then downloading again
-            await this.downloadOfflineFilesProgressAction(fileNames, fileNamesForRoot.length, currentAbortController);
+            await this.downloadOfflineFilesProgressAction(currentDownload, fileNames, fileNamesForRoot.length);
 
-            if (currentAbortController.signal.aborted) {
+            if (currentDownload.abortController.signal.aborted) {
                 return "aborted";
             }
 
-            if (fileNamesForTile.length > 0) {
-                this.store.dispatch(new SetOfflineMapsLastModifiedDateAction(await this.getMetadataPerFile(fileNamesForTile), tileX, tileY));
-            }
-            if (fileNamesForRoot.length > 0) {
-                this.store.dispatch(new SetOfflineMapsLastModifiedDateAction(await this.getMetadataPerFile(fileNamesForRoot), undefined, undefined));
-            }
+            await this.moveDownloadedFilesToDataDirectory(currentDownload, fileNames);
+            // The files that were just moved in are what the app has now, with the versions of the new ones
+            await this.updateDownloadedTilesFromDevice();
+            await this.updateVersionsOfDownloadedFiles();
             return "downloaded";
         } catch (ex) {
+            if (currentDownload.abortController.signal.aborted) {
+                // Aborting makes whatever was going on at that moment fail, which is not an error
+                this.loggingService.info("[Offline Download] The download was aborted while it was going on");
+                return "aborted";
+            }
             const typeAndMessage = this.loggingService.getErrorTypeAndMessage(ex);
             switch (typeAndMessage.type) {
                 case "timeout":
@@ -126,28 +274,23 @@ export class OfflineFilesDownloadService {
             }
             return "error";
         } finally {
-            this.abortController = new AbortController();
-            this._currentDownloadedTile = null;
-        }
-    }
-
-    private async getMetadataPerFile(fileNames: FileNameDateVersion[]): Promise<TileMetadataPerFile> {
-        const metadata: FileNameDateVersion[] = []
-        for (const fileNameAndDate of fileNames) {
-            try {
-                const version = await this.pmtilesService.getVersion(fileNameAndDate.fileName);
-                metadata.push({ fileName: fileNameAndDate.fileName, date: fileNameAndDate.date, version });
-            } catch (ex) {
-                this.loggingService.error(`[Offline Download] Failed to get version for file: ${fileNameAndDate.fileName}, error: ${ex}`);
+            // A download that was aborted might only get here after the next one started, and it is not its to clear
+            if (this.isCurrent(currentDownload)) {
+                this.currentDownload.set(null);
             }
         }
-        return metadata;
     }
 
-    private async downloadOfflineFilesProgressAction(fileNames: FileNameDateVersion[], rootFilesCount: number, abortController: AbortController): Promise<void> {
-        const { tileX, tileY } = this._currentDownloadedTile!;
+    /**
+     * Downloads the files into the cache, where a download that was aborted or failed leaves whatever it
+     * did get, so that downloading the tile again continues from there instead of starting over.
+     */
+    private async downloadOfflineFilesProgressAction(currentDownload: CurrentDownload, fileNames: FileNameDateVersion[], rootFilesCount: number): Promise<void> {
+        const { tileX, tileY, abortController } = currentDownload;
         this.loggingService.info(`[Offline Download] Starting downloading offline files, total files: ${fileNames.length}, tile: ${tileX}-${tileY}`);
         const length = fileNames.length;
+        const progressPerFile: Record<number, number> = {};
+        const alreadyDownloaded = await this.fileService.listFilesInOfflineCache();
         const fileDownloadPromises: Promise<void>[] = [];
         const limit = pLimit(3);
         for (let fileNameIndex = 0; fileNameIndex < length; fileNameIndex++) {
@@ -156,9 +299,9 @@ export class OfflineFilesDownloadService {
                 this.loggingService.info("[Offline Download] Aborted downloading offline files, current file: " + fileName);
                 return;
             }
-            if (this.downloadedFilesInCurrentSession.includes(fileName)) {
+            if (alreadyDownloaded.includes(fileName)) {
                 this.loggingService.info("[Offline Download] File already downloaded recently, skipping: " + fileName);
-                this.updateInProgressTilesList(1, fileNameIndex, length);
+                this.updateProgress(currentDownload, progressPerFile, fileNameIndex, 1, length);
                 continue;
             }
             const token = this.store.selectSnapshot((s: ApplicationState) => s.userState).token;
@@ -167,40 +310,53 @@ export class OfflineFilesDownloadService {
                 fileDownloadUrl += `?tileX=${tileX}&tileY=${tileY}`;
             }
 
-            fileDownloadPromises.push(limit(() => this.downloadAndMove(fileName, fileDownloadUrl, token, abortController, fileNameIndex, length)));
+            fileDownloadPromises.push(limit(() => this.fileService.downloadFileToCacheAuthenticated(fileDownloadUrl, fileName, token,
+                value => this.updateProgress(currentDownload, progressPerFile, fileNameIndex, value, length), abortController)));
         }
         await Promise.all(fileDownloadPromises);
-        this.downloadedFilesInCurrentSession = [];
-        this.loggingService.info(`[Offline Download] Finished downloading offline files, current tile: ${tileX}-${tileY}`);
+        this.loggingService.info(`[Offline Download] Finished downloading offline files, current tile: ${PmTilesService.toTileKey(tileX, tileY)}`);
     }
 
-    private async downloadAndMove(fileName: string, fileDownloadUrl: string, token: string, abortController: AbortController, fileNameIndex: number, length: number) {
-        await this.fileService.downloadFileToCacheAuthenticated(fileDownloadUrl, fileName, token,
-            (value) => this.updateInProgressTilesList(value, fileNameIndex, length), abortController);
-        if (abortController.signal.aborted) {
-            return;
+    /**
+     * Moves the files that were downloaded to where the app reads them from, and extracts the routing
+     * tiles among them. This only happens once every file of the tile was downloaded, so that a download
+     * that was aborted or failed leaves the files of the tile as they were rather than half updated.
+     */
+    private async moveDownloadedFilesToDataDirectory(currentDownload: CurrentDownload, fileNames: FileNameDateVersion[]): Promise<void> {
+        const tileKey = PmTilesService.toTileKey(currentDownload.tileX, currentDownload.tileY);
+        for (const { fileName } of fileNames) {
+            await this.fileService.moveFileFromCacheToDataDirectory(fileName);
+            if (RoutingProvider.isRoutingTilesFile(fileName)) {
+                await this.routingProvider.extractOfflineRoutingTiles(fileName, tileKey);
+            }
         }
-        await this.fileService.moveFileFromCacheToDataDirectory(fileName);
-        this.downloadedFilesInCurrentSession.push(fileName);
-        this.loggingService.info(`[Offline Download] Finished downloading ${fileName}`);
+        this.loggingService.info(`[Offline Download] Moved ${fileNames.length} files of ${tileKey} to the data directory`);
     }
 
-    private updateInProgressTilesList(progressValue: number, fileNameIndex: number, length: number) {
-        if (this._currentDownloadedTile == null) {
+    /**
+     * Reports how far the download of a tile got, where every one of its files weighs the same.
+     * A download that is no longer the current one has nothing to report - its files might still be
+     * coming in after it was aborted, and that says nothing about the download that took its place.
+     */
+    private updateProgress(currentDownload: CurrentDownload, progressPerFile: Record<number, number>,
+        fileNameIndex: number, progressValue: number, length: number) {
+        progressPerFile[fileNameIndex] = progressValue;
+        if (!this.isCurrent(currentDownload)) {
             return;
         }
-        if (fileNameIndex == -1) {
-            this.tilesProgressChanged.emit({ tileX: this._currentDownloadedTile.tileX, tileY: this._currentDownloadedTile.tileY, progressValue: 0 });
-            return;
-        }
-        this._currentDownloadedTile.progress[fileNameIndex] = progressValue;
-        const totalProgress = Object.values(this._currentDownloadedTile.progress).reduce((a, b) => a + b, 0) / length;
-        this.tilesProgressChanged.emit({ tileX: this._currentDownloadedTile.tileX, tileY: this._currentDownloadedTile.tileY, progressValue: totalProgress * 100.0 });
+        const totalProgress = Object.values(progressPerFile).reduce((a, b) => a + b, 0) / length;
+        this.currentDownload.set({ ...currentDownload, progress: totalProgress * 100.0 });
+    }
+
+    /** Whether the given download is the one that is going on, they are told apart by their controller */
+    private isCurrent(currentDownload: CurrentDownload): boolean {
+        return this.currentDownload()?.abortController === currentDownload.abortController;
     }
 
     private async getFilesToDownload(tileX?: number, tileY?: number): Promise<FileNameDateVersion[]> {
-        const offlineState = this.store.selectSnapshot((s: ApplicationState) => s.offlineState);
-        const lastModifiedString = offlineState.downloadedTiles ? this.getLastModifiedDate(offlineState.downloadedTiles[`${tileX}-${tileY}`])?.toISOString() : null;
+        const downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+        const downloadedTile = downloadedTiles[PmTilesService.toTileKey(tileX, tileY)];
+        const lastModifiedString = this.getLastModifiedDate(downloadedTile)?.toISOString();
         const params: Record<string, string> = {};
         if (lastModifiedString) {
             params.lastModified = lastModifiedString;
@@ -208,74 +364,208 @@ export class OfflineFilesDownloadService {
         if (tileX != null && tileY != null) {
             params.tileX = tileX.toString();
             params.tileY = tileY.toString();
+            params.routingTile = "true";
         }
         const fileNames = await firstValueFrom(this.httpClient.get<Record<string, string>>(Urls.offlineFiles, { params: params }).pipe(timeout(5000)));
         this.loggingService.info(`[Offline Download] Got ${Object.keys(fileNames).length} files that needs to be downloaded ${lastModifiedString}`);
         if (Object.keys(fileNames).length === 0) {
             return [];
         }
-        const fileNameDates = Object.entries(fileNames).map(([key, value]) => ({ fileName: key, date: value }));
-        // Only pmtiles and non-contour files.
-        return fileNameDates.filter(fnd => fnd.fileName.endsWith(".pmtiles") && !fnd.fileName.includes("_contour_"));
+        return Object.entries(fileNames).map(([key, value]) => ({ fileName: key, date: value }));
     }
 
     public abortCurrentDownload(): void {
-        this.loggingService.info("[Offline Download] Aborting current download");
-        this.abortController.abort();
-        this.abortController = new AbortController(); // in case finally is never called due to download stuck.
-        this._currentDownloadedTile = null;
-    }
-
-    public async deleteTile(tileX: number, tileY: number): Promise<void> {
-        this.loggingService.info(`[Offline Download] Deleting tile ${tileX}-${tileY}`);
-        let downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.offlineState.downloadedTiles);
-        if (!downloadedTiles) {
-            this.loggingService.info("[Offline Download] No tiles to delete");
+        const currentDownload = this.currentDownload();
+        if (currentDownload == null) {
             return;
         }
-        this.store.dispatch(new DeleteOfflineMapsTileAction(tileX, tileY));
-        const downloadedTile = downloadedTiles[`${tileX}-${tileY}`];
-        if (Array.isArray(downloadedTile)) {
-            const fileNames = downloadedTile.map(fnd => fnd.fileName);
-            for (const fileName of fileNames) {
-                this.loggingService.info(`[Offline Download] Deleting file ${fileName}`);
-                await this.fileService.deleteFileInDataDirectory(fileName);
-                this.pmtilesService.invalidateFile(fileName);
-            }
+        // Every download has an abort controller of its own, so aborting one never touches the next
+        this.loggingService.info("[Offline Download] Aborting the download of " +
+            PmTilesService.toTileKey(currentDownload.tileX, currentDownload.tileY));
+        currentDownload.abortController.abort();
+        this.currentDownload.set(null);
+    }
+
+    public async deleteTile(tileKey: string): Promise<void> {
+        this.loggingService.info(`[Offline Download] Deleting tile ${tileKey}`);
+        const downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+        for (const { fileName } of downloadedTiles[tileKey] ?? []) {
+            this.loggingService.info(`[Offline Download] Deleting file ${fileName}`);
+            await this.fileService.deleteFileInDataDirectory(fileName);
+            this.pmtilesService.invalidateFile(fileName);
         }
-        downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.offlineState.downloadedTiles);
-        if (downloadedTiles && Object.keys(downloadedTiles).length === 1) {
-            this.deleteTile(undefined, undefined);
+        await this.routingProvider.deleteOfflineRoutingTiles(tileKey);
+        await this.updateDownloadedTilesFromDevice();
+        // The root files are only needed as long as there's an area that uses them.
+        const rootTileId = PmTilesService.toTileKey();
+        if (tileKey === rootTileId) {
+            return;
+        }
+        const remainingTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+        if (Object.keys(remainingTiles).length === 1 && remainingTiles[rootTileId] != null) {
+            await this.deleteTile(rootTileId);
         }
     }
 
-    public getLastModifiedDate(downloadedTile: Immutable<TileMetadataPerFile>) {
-        if (!downloadedTile) {
+    /**
+     * Reads what was downloaded into the state, which is the only place it is listed - there's nothing
+     * stored that can go out of sync with the device. The routing tiles are read from the routing plugin,
+     * which is what keeps them, and the rest from the files themselves: the date of a file is the time it
+     * was written, which is when it was downloaded, and its version is only read when it is needed, see
+     * updateVersionsOfDownloadedFiles.
+     * Failing to read the files is logged and otherwise ignored, leaving them in the state as they were.
+     */
+    public async updateDownloadedTilesFromDevice(): Promise<void> {
+        this.store.dispatch(new SetDownloadedRoutingTilesAction(await this.routingProvider.getOfflineRoutingTiles()));
+        let files: DataDirectoryFile[];
+        try {
+            files = await this.fileService.listFilesInDataDirectory();
+        } catch (ex) {
+            this.loggingService.warning(`[Offline Download] Failed to read the files on the device: ${(ex as Error).message}`);
+            return;
+        }
+        const offlineFiles = files.filter(f => f.fileName.endsWith(OfflineFilesDownloadService.OFFLINE_FILE_EXTENSION));
+        const downloadedTiles: Record<string, FileNameDateVersion[]> = {};
+        for (const file of offlineFiles) {
+            const tileKey = OfflineFilesDownloadService.getTileKey(file.fileName);
+            if (tileKey == null) {
+                this.loggingService.warning(`[Offline Download] Can not tell which tile ${file.fileName} belongs to`);
+                continue;
+            }
+            downloadedTiles[tileKey] = [
+                ...downloadedTiles[tileKey] ?? [],
+                { fileName: file.fileName, date: file.modifiedDate.toISOString() }
+            ];
+        }
+        this.logDownloadedTiles(downloadedTiles, offlineFiles);
+        this.store.dispatch(new SetDownloadedTilesAction(downloadedTiles));
+    }
+
+    /**
+     * Reports what the device holds, so that a log a user sends explains what they had to work with.
+     */
+    private logDownloadedTiles(downloadedTiles: Record<string, FileNameDateVersion[]>, offlineFiles: DataDirectoryFile[]): void {
+        if (offlineFiles.length === 0) {
+            this.loggingService.info("[Offline Download] The device holds no offline files");
+            return;
+        }
+        const downloadDates = offlineFiles.map(f => f.modifiedDate.getTime());
+        const totalSize = offlineFiles.reduce((total, file) => total + file.size, 0);
+        const downloadedRoutingTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles);
+        this.loggingService.info(`[Offline Download] The device holds ${offlineFiles.length} files of ` +
+            `${Object.keys(downloadedTiles).length} tiles, ${OfflineFilesDownloadService.toReadableSize(totalSize)}, ` +
+            `downloaded between ${new Date(Math.min(...downloadDates)).toISOString()} and ` +
+            `${new Date(Math.max(...downloadDates)).toISOString()}`);
+        const rootTileKey = PmTilesService.toTileKey();
+        this.loggingService.info(`[Offline Download] The tiles are: ${Object.entries(downloadedTiles)
+            .map(([tileKey, tileFiles]) => `${tileKey === rootTileKey ? "root" : tileKey} ` +
+                `(${tileFiles.length} file${tileFiles.length === 1 ? "" : "s"}` +
+                `${downloadedRoutingTiles.includes(tileKey) ? ", with routing tiles" : ""})`).join(", ")}`);
+    }
+
+    /** A size that is readable in the logs, since they are read by a person and not by a machine */
+    private static toReadableSize(bytes: number): string {
+        const megabytes = bytes / 1024 / 1024;
+        return megabytes >= 1024 ? `${(megabytes / 1024).toFixed(1)} GB` : `${megabytes.toFixed(0)} MB`;
+    }
+
+    /**
+     * Reads the versions of the downloaded files, which means opening every one of them, and only of the
+     * files the styles require a version from - the version of any other file is never compared to anything.
+     */
+    private async updateVersionsOfDownloadedFiles(): Promise<void> {
+        const downloadedTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+        if (Object.keys(this.styleRequirements.minVersionPerFile).length === 0) {
+            return;
+        }
+        const tilesWithVersions: Record<string, FileNameDateVersion[]> = {};
+        for (const [tileKey, files] of Object.entries(downloadedTiles)) {
+            tilesWithVersions[tileKey] = [];
+            for (const file of files) {
+                const sourceFileName = OfflineFilesDownloadService.getSourceFileName(file.fileName).toLowerCase();
+                if (file.version != null || this.styleRequirements.minVersionPerFile[sourceFileName] == null) {
+                    tilesWithVersions[tileKey].push(file);
+                    continue;
+                }
+                tilesWithVersions[tileKey].push({ ...file, version: await this.getVersion(file.fileName) });
+            }
+        }
+        this.store.dispatch(new SetDownloadedTilesAction(tilesWithVersions));
+    }
+
+    /** The version of a file, undefined when it has none or when the file can not be read */
+    private async getVersion(fileName: string): Promise<string | undefined> {
+        try {
+            return await this.pmtilesService.getVersion(fileName);
+        } catch (ex) {
+            this.loggingService.error(`[Offline Download] Failed to get the version of ${fileName}: ${(ex as Error).message}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Deletes the offline files whose source is not used by the styles nor by the app - a source that was
+     * removed or renamed leaves its files behind, only taking up space. Only the offline map files are
+     * deleted, the styles and any other file that is stored in the same directory are not this service's.
+     */
+    private async deleteFilesOfUnusedSources(): Promise<void> {
+        if (this.styleRequirements.sourceFileNames.length === 0) {
+            this.loggingService.warning("[Offline Download] The styles have no sources, keeping all the files");
+            return;
+        }
+        const usedSourceFileNames = [...this.styleRequirements.sourceFileNames, ...OfflineFilesDownloadService.APPLICATION_SOURCE_FILE_NAMES];
+        const files = await this.fileService.listFilesInDataDirectory();
+        for (const { fileName } of files) {
+            const sourceFileName = OfflineFilesDownloadService.getSourceFileName(fileName).toLowerCase();
+            if (!fileName.endsWith(OfflineFilesDownloadService.OFFLINE_FILE_EXTENSION) ||
+                usedSourceFileNames.includes(sourceFileName)) {
+                continue;
+            }
+            this.loggingService.info(`[Offline Download] Deleting ${fileName}, ${sourceFileName} is not a source of the styles`);
+            await this.fileService.deleteFileInDataDirectory(fileName);
+            this.pmtilesService.invalidateFile(fileName);
+        }
+    }
+
+    /** The time the newest file of a tile was downloaded at, which is when the tile was last updated */
+    public getLastModifiedDate(files: Immutable<FileNameDateVersion[]>) {
+        if (!files?.length) {
             return null;
         }
         let lastModified = new Date(0);
-        if (Array.isArray(downloadedTile)) {
-            for (const fileDateVersion of downloadedTile as FileNameDateVersion[]) {
-                const fileUpdateDate = new Date(fileDateVersion.date);
-                if (fileUpdateDate > lastModified) {
-                    lastModified = new Date(fileDateVersion.date)
-                }
+        for (const { date } of files) {
+            if (new Date(date) > lastModified) {
+                lastModified = new Date(date);
             }
-        } else {
-            lastModified = new Date(downloadedTile as Date);
         }
         return lastModified;
     }
 
-    public isTileCompatible(downloadedTile: Immutable<TileMetadataPerFile>): boolean {
-        if (!Array.isArray(downloadedTile)) {
-            return Object.keys(this.metadata).every(k => !k.includes("min-version"));
+    /**
+     * Whether the files of a tile are still the ones the app needs: they are new enough for the style,
+     * and the tile has everything it should - a tile that was downloaded before offline routing existed
+     * has no routing tiles, and needs to be downloaded again. The root files are not of a specific area,
+     * so they have no routing tiles of their own.
+     * A file the style requires a version from but that has none is treated as too old, either it was
+     * downloaded before the versions existed or it can not be read.
+     */
+    public isTileCompatible(tileKey: string, files: Immutable<FileNameDateVersion[]>): boolean {
+        const downloadedRoutingTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles);
+        if (tileKey !== PmTilesService.toTileKey() && !downloadedRoutingTiles.includes(tileKey)) {
+            return false;
         }
-        for (const fileDateVersion of downloadedTile as FileNameDateVersion[]) {
-            const fileVersion = fileDateVersion.version;
-            const sourceName = fileDateVersion.fileName.split("+")[0];
-            const styleVersion = this.metadata[`sources:${sourceName}:min-version`];
-            if (fileVersion && styleVersion && fileVersion.localeCompare(styleVersion, undefined, { numeric: true, sensitivity: "base" }) === -1) {
+        for (const fileDateVersion of files) {
+            const sourceFileName = OfflineFilesDownloadService.getSourceFileName(fileDateVersion.fileName);
+            const minVersion = this.styleRequirements.minVersionPerFile[sourceFileName.toLowerCase()];
+            if (minVersion == null) {
+                continue;
+            }
+            if (!fileDateVersion.version) {
+                this.loggingService.info(`[Offline Download] ${fileDateVersion.fileName} has no version ` +
+                    `while the style requires ${minVersion}, tile: ${tileKey}`);
+                return false;
+            }
+            if (OfflineFilesDownloadService.compareVersions(fileDateVersion.version, minVersion) < 0) {
                 return false;
             }
         }

--- a/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
+++ b/IsraelHiking.Web/src/application/services/offline-files-download.service.ts
@@ -1,4 +1,4 @@
-﻿import { computed, inject, Service, signal } from "@angular/core";
+import { computed, inject, Service, signal } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Router } from "@angular/router";
 import { timeout } from "rxjs/operators";
@@ -15,10 +15,9 @@ import { LoggingService } from "./logging.service";
 import { ToastService } from "./toast.service";
 import { ResourcesService } from "./resources.service";
 import { PmTilesService } from "./pmtiles.service";
-import { RoutingProvider } from "./routing.provider";
 import { RunningContextService } from "./running-context.service";
 import { RouteStrings } from "./hash.service";
-import { SetDownloadedRoutingTilesAction, SetDownloadedTilesAction } from "../reducers/in-memory.reducer";
+import { SetDownloadedTilesAction } from "../reducers/in-memory.reducer";
 import type { ApplicationState, FileNameDateVersion } from "../models";
 
 /** What the styles need from the offline files, see readStyleRequirements */
@@ -59,7 +58,6 @@ export class OfflineFilesDownloadService {
     private readonly httpClient = inject(HttpClient);
     private readonly toastService = inject(ToastService);
     private readonly pmtilesService = inject(PmTilesService);
-    private readonly routingProvider = inject(RoutingProvider);
     private readonly runningContextService = inject(RunningContextService);
     private readonly store = inject(Store);
     private readonly router = inject(Router);
@@ -231,7 +229,6 @@ export class OfflineFilesDownloadService {
             for (const styleAndContent of styles) {
                 await this.fileService.writeStyle(styleAndContent.fileName, styleAndContent.content);
             }
-            await this.routingProvider.updateOfflineRoutingProfiles();
             await this.deleteFilesOfUnusedSources();
             // What is asked of the server is decided by the state, so it is read again now that files were deleted
             await this.updateDownloadedTilesFromDevice();
@@ -318,17 +315,14 @@ export class OfflineFilesDownloadService {
     }
 
     /**
-     * Moves the files that were downloaded to where the app reads them from, and extracts the routing
-     * tiles among them. This only happens once every file of the tile was downloaded, so that a download
-     * that was aborted or failed leaves the files of the tile as they were rather than half updated.
+     * Moves the files that were downloaded to where the app reads them from. This only happens once
+     * every file of the tile was downloaded, so that a download that was aborted or failed leaves the
+     * files of the tile as they were rather than half updated.
      */
     private async moveDownloadedFilesToDataDirectory(currentDownload: CurrentDownload, fileNames: FileNameDateVersion[]): Promise<void> {
         const tileKey = PmTilesService.toTileKey(currentDownload.tileX, currentDownload.tileY);
         for (const { fileName } of fileNames) {
             await this.fileService.moveFileFromCacheToDataDirectory(fileName);
-            if (RoutingProvider.isRoutingTilesFile(fileName)) {
-                await this.routingProvider.extractOfflineRoutingTiles(fileName, tileKey);
-            }
         }
         this.loggingService.info(`[Offline Download] Moved ${fileNames.length} files of ${tileKey} to the data directory`);
     }
@@ -364,7 +358,6 @@ export class OfflineFilesDownloadService {
         if (tileX != null && tileY != null) {
             params.tileX = tileX.toString();
             params.tileY = tileY.toString();
-            params.routingTile = "true";
         }
         const fileNames = await firstValueFrom(this.httpClient.get<Record<string, string>>(Urls.offlineFiles, { params: params }).pipe(timeout(5000)));
         this.loggingService.info(`[Offline Download] Got ${Object.keys(fileNames).length} files that needs to be downloaded ${lastModifiedString}`);
@@ -394,7 +387,6 @@ export class OfflineFilesDownloadService {
             await this.fileService.deleteFileInDataDirectory(fileName);
             this.pmtilesService.invalidateFile(fileName);
         }
-        await this.routingProvider.deleteOfflineRoutingTiles(tileKey);
         await this.updateDownloadedTilesFromDevice();
         // The root files are only needed as long as there's an area that uses them.
         const rootTileId = PmTilesService.toTileKey();
@@ -409,14 +401,12 @@ export class OfflineFilesDownloadService {
 
     /**
      * Reads what was downloaded into the state, which is the only place it is listed - there's nothing
-     * stored that can go out of sync with the device. The routing tiles are read from the routing plugin,
-     * which is what keeps them, and the rest from the files themselves: the date of a file is the time it
-     * was written, which is when it was downloaded, and its version is only read when it is needed, see
-     * updateVersionsOfDownloadedFiles.
+     * stored that can go out of sync with the device. It is read from the files themselves: the date of a
+     * file is the time it was written, which is when it was downloaded, and its version is only read when
+     * it is needed, see updateVersionsOfDownloadedFiles.
      * Failing to read the files is logged and otherwise ignored, leaving them in the state as they were.
      */
     public async updateDownloadedTilesFromDevice(): Promise<void> {
-        this.store.dispatch(new SetDownloadedRoutingTilesAction(await this.routingProvider.getOfflineRoutingTiles()));
         let files: DataDirectoryFile[];
         try {
             files = await this.fileService.listFilesInDataDirectory();
@@ -451,7 +441,6 @@ export class OfflineFilesDownloadService {
         }
         const downloadDates = offlineFiles.map(f => f.modifiedDate.getTime());
         const totalSize = offlineFiles.reduce((total, file) => total + file.size, 0);
-        const downloadedRoutingTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles);
         this.loggingService.info(`[Offline Download] The device holds ${offlineFiles.length} files of ` +
             `${Object.keys(downloadedTiles).length} tiles, ${OfflineFilesDownloadService.toReadableSize(totalSize)}, ` +
             `downloaded between ${new Date(Math.min(...downloadDates)).toISOString()} and ` +
@@ -459,8 +448,7 @@ export class OfflineFilesDownloadService {
         const rootTileKey = PmTilesService.toTileKey();
         this.loggingService.info(`[Offline Download] The tiles are: ${Object.entries(downloadedTiles)
             .map(([tileKey, tileFiles]) => `${tileKey === rootTileKey ? "root" : tileKey} ` +
-                `(${tileFiles.length} file${tileFiles.length === 1 ? "" : "s"}` +
-                `${downloadedRoutingTiles.includes(tileKey) ? ", with routing tiles" : ""})`).join(", ")}`);
+                `(${tileFiles.length} file${tileFiles.length === 1 ? "" : "s"})`).join(", ")}`);
     }
 
     /** A size that is readable in the logs, since they are read by a person and not by a machine */
@@ -542,18 +530,11 @@ export class OfflineFilesDownloadService {
     }
 
     /**
-     * Whether the files of a tile are still the ones the app needs: they are new enough for the style,
-     * and the tile has everything it should - a tile that was downloaded before offline routing existed
-     * has no routing tiles, and needs to be downloaded again. The root files are not of a specific area,
-     * so they have no routing tiles of their own.
+     * Whether the files of a tile are still the ones the app needs, i.e. new enough for the style.
      * A file the style requires a version from but that has none is treated as too old, either it was
      * downloaded before the versions existed or it can not be read.
      */
     public isTileCompatible(tileKey: string, files: Immutable<FileNameDateVersion[]>): boolean {
-        const downloadedRoutingTiles = this.store.selectSnapshot((s: ApplicationState) => s.inMemoryState.downloadedRoutingTiles);
-        if (tileKey !== PmTilesService.toTileKey() && !downloadedRoutingTiles.includes(tileKey)) {
-            return false;
-        }
         for (const fileDateVersion of files) {
             const sourceFileName = OfflineFilesDownloadService.getSourceFileName(fileDateVersion.fileName);
             const minVersion = this.styleRequirements.minVersionPerFile[sourceFileName.toLowerCase()];

--- a/IsraelHiking.Web/src/application/services/pmtiles.service.ts
+++ b/IsraelHiking.Web/src/application/services/pmtiles.service.ts
@@ -1,4 +1,4 @@
-import { inject, Service } from "@angular/core";
+﻿import { inject, Service } from "@angular/core";
 import { Directory, Filesystem } from "@capacitor/filesystem";
 import { Source, RangeResponse, PMTiles } from "pmtiles";
 import { Store } from "@ngxs/store";
@@ -105,14 +105,15 @@ export class PmTilesService {
         if (z >= TILES_ZOOM) {
             ({ tileX, tileY } = SpatialService.getParentZoomTileCoordinates({ x, y }, z, TILES_ZOOM));
         }
-        if (this.store.selectSnapshot((state: ApplicationState) => state.offlineState).downloadedTiles?.[`${tileX}-${tileY}`] == null) {
+        const downloadedTiles = this.store.selectSnapshot((state: ApplicationState) => state.inMemoryState.downloadedTiles);
+        if (downloadedTiles[PmTilesService.toTileKey(tileX, tileY)] == null) {
             return false;
         }
         const fileName = this.getFileNameByType(z, x, y, type);
         try {
             await this.getSource(fileName);
         } catch (ex) {
-            this.loggingService.debug(`Failed to open file ${fileName} for tile ${tileX}-${tileY} type ${type} and ${z}/${x}/${y}: ${(ex as Error).message}`);
+            this.loggingService.debug(`Failed to open file ${fileName} for tile ${PmTilesService.toTileKey(tileX, tileY)} type ${type} and ${z}/${x}/${y}: ${(ex as Error).message}`);
             return false;
         }
         return true;
@@ -122,5 +123,23 @@ export class PmTilesService {
         const source = await this.getSource(fileName);
         const pmTilesProvider = new PMTiles(source);
         return (await pmTilesProvider.getMetadata() as { version?: string })?.version;
+    }
+
+    /**
+     * The key the files of a tile are stored under, where an undefined tile is the root, non-tiled, one.
+     */
+    public static toTileKey(tileX?: number, tileY?: number): string {
+        return `${tileX}-${tileY}`;
+    }
+
+    /**
+     * The tile a key was made of, null for the root key, which is not of a specific tile.
+     */
+    public static fromTileKey(tileKey: string): { tileX: number, tileY: number } | null {
+        const [tileX, tileY] = tileKey.split("-").map(Number);
+        if (!Number.isInteger(tileX) || !Number.isInteger(tileY)) {
+            return null;
+        }
+        return { tileX, tileY };
     }
 }

--- a/IsraelHiking.Web/src/application/services/pmtiles.service.ts
+++ b/IsraelHiking.Web/src/application/services/pmtiles.service.ts
@@ -1,4 +1,4 @@
-﻿import { inject, Service } from "@angular/core";
+import { inject, Service } from "@angular/core";
 import { Directory, Filesystem } from "@capacitor/filesystem";
 import { Source, RangeResponse, PMTiles } from "pmtiles";
 import { Store } from "@ngxs/store";

--- a/IsraelHiking.Web/src/application/services/purchase.service.ts
+++ b/IsraelHiking.Web/src/application/services/purchase.service.ts
@@ -1,4 +1,4 @@
-import { inject, Service } from "@angular/core";
+﻿import { computed, inject, Service } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Store } from "@ngxs/store";
 import { firstValueFrom, timeout } from "rxjs";
@@ -21,6 +21,19 @@ export class PurchaseService {
     private readonly loggingService = inject(LoggingService);
     private readonly httpClient = inject(HttpClient);
     private readonly store = inject(Store);
+
+    private readonly isSubscribed = this.store.selectSignal((s: ApplicationState) => s.offlineState.isSubscribed);
+    private readonly downloadedTiles = this.store.selectSignal((s: ApplicationState) => s.inMemoryState.downloadedTiles);
+    /** Whether there are any offline files on the device, i.e. whether this user ever downloaded an area */
+    private readonly hasDownloadedTiles = computed(() => Object.keys(this.downloadedTiles()).length > 0);
+
+    /** The subscription can be bought by a user that has no offline files, and renewed by one that has */
+    public readonly isPurchaseAvailable = computed(() =>
+        this.runningContextService.isCapacitor && !this.isSubscribed() && !this.hasDownloadedTiles());
+
+    /** @see isPurchaseAvailable */
+    public readonly isRenewAvailable = computed(() =>
+        this.runningContextService.isCapacitor && !this.isSubscribed() && this.hasDownloadedTiles());
 
     public async initialize() {
         if (!this.runningContextService.isCapacitor) {
@@ -97,20 +110,6 @@ export class PurchaseService {
             await Purchases.syncPurchases();
             await this.checkAndUpdateOfflineAvailability();
         }
-    }
-
-    public isPurchaseAvailable(): boolean {
-        const offlineState = this.store.selectSnapshot((s: ApplicationState) => s.offlineState);
-        return this.runningContextService.isCapacitor &&
-            !offlineState.isSubscribed &&
-            offlineState.downloadedTiles == null;
-    }
-
-    public isRenewAvailable() {
-        const offlineState = this.store.selectSnapshot((s: ApplicationState) => s.offlineState);
-        return this.runningContextService.isCapacitor &&
-            !offlineState.isSubscribed &&
-            offlineState.downloadedTiles != null;
     }
 
     private shouldShowPaywall(): boolean {

--- a/IsraelHiking.Web/src/application/services/purchase.service.ts
+++ b/IsraelHiking.Web/src/application/services/purchase.service.ts
@@ -1,4 +1,4 @@
-﻿import { computed, inject, Service } from "@angular/core";
+import { computed, inject, Service } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Store } from "@ngxs/store";
 import { firstValueFrom, timeout } from "rxjs";

--- a/IsraelHiking.Web/src/application/services/resources.service.ts
+++ b/IsraelHiking.Web/src/application/services/resources.service.ts
@@ -232,6 +232,9 @@ export class ResourcesService {
     public noDescriptionAvailableInYourLanguage: string;
     public clickTheMapToSelectATile: string;
     public clickBelow: string;
+    public oneTileNeedsToBeDownloadedAgain: string;
+    public tilesNeedToBeDownloadedAgain: string;
+    public download: string;
     public translatedBy: string;
     public clickToTranslate: string;
     public minimize: string;
@@ -662,6 +665,9 @@ export class ResourcesService {
         this.noDescriptionAvailableInYourLanguage = this.gettextCatalog.getString("No description available in your language");
         this.clickTheMapToSelectATile = this.gettextCatalog.getString("Click the map to select a tile");
         this.clickBelow = this.gettextCatalog.getString("Click below");
+        this.oneTileNeedsToBeDownloadedAgain = this.gettextCatalog.getString("One tile needs to be downloaded again");
+        this.tilesNeedToBeDownloadedAgain = this.gettextCatalog.getString("{{count}} tiles need to be downloaded again");
+        this.download = this.gettextCatalog.getString("Download");
         this.translatedBy = this.gettextCatalog.getString("Translated by LibreTranslate, click to view original text");
         this.clickToTranslate = this.gettextCatalog.getString("Click to translate");
         this.minimize = this.gettextCatalog.getString("Minimize");

--- a/IsraelHiking.Web/src/scss/common.scss
+++ b/IsraelHiking.Web/src/scss/common.scss
@@ -26,6 +26,7 @@ html {
     @include mat.button-overrides($low-emphasis-button-labels);
 
     --brand-color: #32cd6d;
+    --warning-color: #8a5a00;
     @include mat.theme-overrides((primary: var(--brand-color), on-primary: #003018));
 }
 
@@ -37,6 +38,8 @@ html {
         ));
     color-scheme: dark;
     @include mat.button-overrides($low-emphasis-button-labels);
+
+    --warning-color: #ffc107;
 }
 
 .error-button {

--- a/IsraelHiking.Web/src/scss/import-tailwind.css
+++ b/IsraelHiking.Web/src/scss/import-tailwind.css
@@ -12,4 +12,5 @@
     --color-on-surface: var(--mat-sys-on-surface);
     --color-outline-variant: var(--mat-sys-outline-variant);
     --color-brand: var(--brand-color);
+    --color-warning: var(--warning-color);
 }

--- a/IsraelHiking.Web/src/translations/ar.json
+++ b/IsraelHiking.Web/src/translations/ar.json
@@ -111,6 +111,7 @@
     "Distance": "المسافة",
     "Distance markers": "علامات المسافة",
     "Don't show this message again": "لا تعرض هذه الرسالة مرة أخرى",
+    "Download": "تنزيل",
     "Download finished successfully!": "تم الانتهاء من تحميله بنجاح!",
     "Download Map for Offline viewing": "تحميل خريطة للاستخدام غير المتصل",
     "Drinking Water": "مياه شرب",
@@ -229,6 +230,7 @@
     "Not yet...": "ليس بعد...",
     "Observation Tower": "برج المراقبة",
     "OK": "حسناً",
+    "One tile needs to be downloaded again": "يجب تنزيل مربع واحد مرة أخرى",
     "Oops, something went wrong. Please try again later": "عذرًا، حدث خطأ. يرجى المحاولة مرة أخرى لاحقًا",
     "Opacity": "شفافية",
     "Open a File": "فتح ملف",
@@ -402,5 +404,6 @@
     "Yes": "نعم",
     "You have more than 10 routes which can cause performance issues.": "لديك أكثر من 10 مسارات، وقد يتسبب ذلك في مشاكل في الأداء.",
     "Zoom In": "تكبير",
-    "Zoom Out": "تصغير"
+    "Zoom Out": "تصغير",
+    "{{count}} tiles need to be downloaded again": "يجب تنزيل {{count}} مربعات مرة أخرى"
 }

--- a/IsraelHiking.Web/src/translations/en-US.json
+++ b/IsraelHiking.Web/src/translations/en-US.json
@@ -111,6 +111,7 @@
     "Distance": "Distance",
     "Distance markers": "Distance markers",
     "Don't show this message again": "Don't show this message again",
+    "Download": "Download",
     "Download finished successfully!": "Download finished successfully!",
     "Download Map for Offline viewing": "Download Map for Offline viewing",
     "Drinking Water": "Drinking Water",
@@ -229,6 +230,7 @@
     "Not yet...": "Not yet...",
     "Observation Tower": "Observation Tower",
     "OK": "OK",
+    "One tile needs to be downloaded again": "One tile needs to be downloaded again",
     "Oops, something went wrong. Please try again later": "Oops, something went wrong. Please try again later",
     "Opacity": "Opacity",
     "Open a File": "Open a File",
@@ -402,5 +404,6 @@
     "Yes": "Yes",
     "You have more than 10 routes which can cause performance issues.": "You have more than 10 routes which can cause performance issues.",
     "Zoom In": "Zoom In",
-    "Zoom Out": "Zoom Out"
+    "Zoom Out": "Zoom Out",
+    "{{count}} tiles need to be downloaded again": "{{count}} tiles need to be downloaded again"
 }

--- a/IsraelHiking.Web/src/translations/es.json
+++ b/IsraelHiking.Web/src/translations/es.json
@@ -111,6 +111,7 @@
     "Distance": "Distancia",
     "Distance markers": "Marcadores de distancia",
     "Don't show this message again": "No mostrar este mensaje de nuevo",
+    "Download": "Descargar",
     "Download finished successfully!": "¡Descarga completada con éxito!",
     "Download Map for Offline viewing": "Descargar mapa para uso sin conexión",
     "Drinking Water": "Agua potable",
@@ -229,6 +230,7 @@
     "Not yet...": "Aún no...",
     "Observation Tower": "Torre de observación",
     "OK": "Aceptar",
+    "One tile needs to be downloaded again": "Un mosaico debe descargarse de nuevo",
     "Oops, something went wrong. Please try again later": "Vaya, algo salió mal. Por favor, inténtalo de nuevo más tarde",
     "Opacity": "Opacidad",
     "Open a File": "Abrir un archivo",
@@ -402,5 +404,6 @@
     "Yes": "Sí",
     "You have more than 10 routes which can cause performance issues.": "Tienes más de 10 rutas, lo que puede causar problemas de rendimiento.",
     "Zoom In": "Acercar",
-    "Zoom Out": "Alejar"
+    "Zoom Out": "Alejar",
+    "{{count}} tiles need to be downloaded again": "{{count}} mosaicos deben descargarse de nuevo"
 }

--- a/IsraelHiking.Web/src/translations/he.json
+++ b/IsraelHiking.Web/src/translations/he.json
@@ -111,6 +111,7 @@
     "Distance": "מרחק",
     "Distance markers": "סימני מרחק",
     "Don't show this message again": "אל תציג הודעה זו שוב",
+    "Download": "הורידו",
     "Download finished successfully!": "ההורדה הסתיימה בהצלחה!",
     "Download Map for Offline viewing": "הורידו מפות לצפיה ללא חיבור לרשת",
     "Drinking Water": "מי שתיה",
@@ -229,6 +230,7 @@
     "Not yet...": "עוד לא...",
     "Observation Tower": "מגדל תצפית",
     "OK": "אישור",
+    "One tile needs to be downloaded again": "יש להוריד מחדש אריח אחד",
     "Oops, something went wrong. Please try again later": "אופס, משהו השתבש. אנא נסו שנית מאוחר יותר",
     "Opacity": "שקיפות",
     "Open a File": "פתיחת קובץ",
@@ -402,5 +404,6 @@
     "Yes": "כן",
     "You have more than 10 routes which can cause performance issues.": "יש לך יותר מעשרה מסלולים בתכנון, מה שיכול לגרום לבעיות ביצועים.",
     "Zoom In": "הגדלת המפה",
-    "Zoom Out": "הקטנת המפה"
+    "Zoom Out": "הקטנת המפה",
+    "{{count}} tiles need to be downloaded again": "יש להוריד מחדש {{count}} אריחים"
 }

--- a/IsraelHiking.Web/src/translations/ru.json
+++ b/IsraelHiking.Web/src/translations/ru.json
@@ -111,6 +111,7 @@
     "Distance": "Расстояние",
     "Distance markers": "Маркеры расстояния",
     "Don't show this message again": "Не показывать это сообщение снова",
+    "Download": "Загрузить",
     "Download finished successfully!": "Загрузка завершена успешно!",
     "Download Map for Offline viewing": "Загрузите карту для офлайн-использования",
     "Drinking Water": "Питьевая вода",
@@ -229,6 +230,7 @@
     "Not yet...": "Ещё не...",
     "Observation Tower": "Смотровая башня",
     "OK": "ОК",
+    "One tile needs to be downloaded again": "Одну плитку нужно загрузить заново",
     "Oops, something went wrong. Please try again later": "Упс, что-то пошло не так. Пожалуйста, попробуйте позже",
     "Opacity": "Прозрачность",
     "Open a File": "Открыть файл",
@@ -402,5 +404,6 @@
     "Yes": "Да",
     "You have more than 10 routes which can cause performance issues.": "У вас есть более 10 маршрутов, что может вызвать проблемы с производительностью.",
     "Zoom In": "Увеличить",
-    "Zoom Out": "Уменьшить"
+    "Zoom Out": "Уменьшить",
+    "{{count}} tiles need to be downloaded again": "Плиток нужно загрузить заново: {{count}}"
 }


### PR DESCRIPTION
- Resolves #2642

As described in the issue:
- Show that there are incompatible tiles and have a next button to toggle between them
- Improve the end of download experience and solve the original bug that caused this issue
- Use the downloaded files as the single source of truth